### PR TITLE
Add HF integration

### DIFF
--- a/models/vision_language_model.py
+++ b/models/vision_language_model.py
@@ -6,7 +6,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-class VisionLanguageModel(nn.Module):
+from huggingface_hub import PyTorchModelHubMixin
+
+class VisionLanguageModel(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/huggingface/nanoVLM"):
     def __init__(self, cfg):
         super().__init__()
         self.cfg = cfg
@@ -98,11 +100,3 @@ class VisionLanguageModel(nn.Module):
         print(f"Loading weights from full VLM checkpoint: {path}")
         checkpoint = torch.load(path, map_location=torch.device('cuda' if torch.cuda.is_available() else 'cpu'))        
         self.load_state_dict(checkpoint)
-
-    @classmethod
-    def from_pretrained(cls, cfg):
-        model = cls(cfg)
-        model.vision_encoder = ViT.from_pretrained(cfg)
-        model.decoder = LanguageModel.from_pretrained(cfg)
-
-        return model

--- a/models/vision_language_model.py
+++ b/models/vision_language_model.py
@@ -8,7 +8,8 @@ import torch.nn.functional as F
 
 from huggingface_hub import PyTorchModelHubMixin
 
-class VisionLanguageModel(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/huggingface/nanoVLM"):
+class VisionLanguageModel(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/huggingface/nanoVLM", 
+                          library_name="nanovlm", tags=["image-text-to-text"], license="mit"):
     def __init__(self, cfg):
         super().__init__()
         self.cfg = cfg

--- a/models/vision_language_model.py
+++ b/models/vision_language_model.py
@@ -1,3 +1,4 @@
+from models.config import VLMConfig
 from models.vision_transformer import ViT
 from models.language_model import LanguageModel
 from models.modality_projector import ModalityProjector
@@ -10,7 +11,7 @@ from huggingface_hub import PyTorchModelHubMixin
 
 class VisionLanguageModel(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/huggingface/nanoVLM", 
                           library_name="nanovlm", tags=["image-text-to-text"], license="mit"):
-    def __init__(self, cfg):
+    def __init__(self, cfg: VLMConfig):
         super().__init__()
         self.cfg = cfg
         self.vision_encoder = ViT(cfg)


### PR DESCRIPTION
This PR  equips the main model class with:

* `from_pretrained`, `save_pretrained`and`push_to_hub` capabilities
* safetensors for weights serialization (if you do `model.save_pretrained("...")` or `model.push_to_hub("...")`)
* track download numbers for models pushed to the hub, similar to models in the Transformers library
* push an automated model card.

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from models.vision_language_model import VisionLanguageModel
from models.config import VLMConfig

cfg = VLMConfig()
model = VisionLanguageModel(cfg)

# save it locally like so
model.save_pretrained("my-nanovlm-model")

# or push a trained model to the hub
model.push_to_hub("nielsr/my-awesome-nanovlm-model")

# now anyone can use it like so
model = VisionLanguageModel.from_pretrained("nielsr/my-awesome-nanovlm-model")
```