### PR TITLE
Vanilla HF integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,59 @@ Generation 4:  This is a cute cat sitting on the surface of the mat. The backgro
 Generation 5:  This is a cat sitting on a rug, which is on the ground. The cat is in brown
 ```
 
+## Hub integration
+
+**nanoVLM** comes with handy methods to load and save the model from the Hugging Face Hub.
+
+### Pretrained weights
+
+Here is how to load from a repo on the Hugging Face Hub. This is the recommended way to start working with the pretrained weights.
+
+```python
+# Load pretrained weights from Hub
+from models.vision_language_model import VisionLanguageModel
+
+model = VisionLanguageModel.from_pretrained("lusxvr/nanoVLM-222M")
+```
+
+### Push to hub
+
+Once you've trained a **nanoVLM** model, you might want to share it on the Hugging Face Hub. You can easily do that with:
+
+```python
+... # Load and train your model
+
+# Push it to `username/my-awesome-nanovlm-model` repo
+model.push_to_hub("my-awesome-nanovlm-model")
+```
+
+The model will be saved on the Hub as a config file `config.json` and a weights file `model.safetensors`. A modelcard `README.md` will also be generated for you with some high-level information. Feel free to update it manually to explain your work.
+
+If the repo does not exist, it will be created for you. By default the repo will be public. You can pass `private=True` if you don't want to share publicly.
+
+
+### Local save/load
+
+If you don't want to host your model on the Hugging Face Hub, it is still possible to save it locally:
+
+```python
+... # Load and train your model
+
+# Save it to a local folder
+model.save_pretrained("path/to/local/model")
+```
+
+You can then reload it from the local path:
+
+```python
+# Load pretrained weights from local path
+from models.vision_language_model import VisionLanguageModel
+
+model = VisionLanguageModel.from_pretrained("path/to/local/model")
+```
+
 ## Citation
+
 If you like the project and want to use it somewhere, please use this citation:
 ```
 @misc{wiedmann2025nanovlm,

--- a/generate.py
+++ b/generate.py
@@ -1,25 +1,20 @@
 import torch
 from PIL import Image
-from huggingface_hub import hf_hub_download
 
 from models.vision_language_model import VisionLanguageModel
-from models.config import VLMConfig
 from data.processors import get_tokenizer, get_image_processor
 
 torch.manual_seed(0)
 
-cfg = VLMConfig()
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 print(f"Using device: {device}")
 
-# Change to your own model path after training
-path_to_hf_file = hf_hub_download(repo_id="lusxvr/nanoVLM-222M", filename="nanoVLM-222M.pth")
-model = VisionLanguageModel(cfg).to(device)
-model.load_checkpoint(path_to_hf_file)
+# Load model from the Hugging Face Hub or a local directory
+model = VisionLanguageModel.from_pretrained("lusxvr/nanoVLM-222M").to(device)
 model.eval()
 
-tokenizer = get_tokenizer(cfg.lm_tokenizer)
-image_processor = get_image_processor(cfg.vit_img_size)
+tokenizer = get_tokenizer(model.cfg.lm_tokenizer)
+image_processor = get_image_processor(model.cfg.vit_img_size)
 
 text = "What is this?"
 template = f"Question: {text} Answer:"

--- a/models/vision_language_model.py
+++ b/models/vision_language_model.py
@@ -1,18 +1,18 @@
-import json
 import os
+import json
 import tempfile
 from dataclasses import asdict
+
+
+from models.vision_transformer import ViT
+from models.language_model import LanguageModel
+from models.modality_projector import ModalityProjector
+from models.config import VLMConfig
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from safetensors.torch import load_model, save_model
-
-from models.config import VLMConfig
-from models.language_model import LanguageModel
-from models.modality_projector import ModalityProjector
-from models.vision_transformer import ViT
-
 
 class VisionLanguageModel(nn.Module):
     def __init__(self, cfg: VLMConfig):
@@ -28,38 +28,26 @@ class VisionLanguageModel(nn.Module):
 
         token_embd = self.decoder.token_embedding(input_ids)
 
-        combined_embd = torch.cat(
-            (image_embd, token_embd), dim=1
-        )  # Concatenate image embeddings to token embeddings
-
+        combined_embd = torch.cat((image_embd, token_embd), dim=1) # Concatenate image embeddings to token embeddings
+        
         # Adjust attention mask to account for image tokens
         if attention_mask is not None:
             # Create mask of 1s for image tokens (all image tokens should be attended to)
             batch_size = image_embd.size(0)
             img_seq_len = image_embd.size(1)
-            image_attention_mask = torch.ones(
-                (batch_size, img_seq_len),
-                device=attention_mask.device,
-                dtype=attention_mask.dtype,
-            )
-
+            image_attention_mask = torch.ones((batch_size, img_seq_len), device=attention_mask.device, dtype=attention_mask.dtype)
+            
             # Combine image and token attention masks
             attention_mask = torch.cat((image_attention_mask, attention_mask), dim=1)
 
-        logits = self.decoder(
-            combined_embd, attention_mask
-        )  # Not logits yet, but easier to return like this
+        logits = self.decoder(combined_embd, attention_mask) # Not logits yet, but easier to return like this
 
         loss = None
         if targets is not None:
             # Only use the token part of the logits for loss computation
             logits = self.decoder.head(logits)
-            logits = logits[:, image_embd.size(1) :, :]
-            loss = F.cross_entropy(
-                logits.reshape(-1, logits.size(-1)),
-                targets.reshape(-1),
-                ignore_index=-100,
-            )
+            logits = logits[:, image_embd.size(1):, :]
+            loss = F.cross_entropy(logits.reshape(-1, logits.size(-1)), targets.reshape(-1), ignore_index=-100)
 
         return logits, loss
 
@@ -68,10 +56,10 @@ class VisionLanguageModel(nn.Module):
         # Process image through vision encoder and projection
         image_embd = self.vision_encoder(image)
         image_embd = self.MP(image_embd)
-
+        
         # Embed initial tokens
         token_embd = self.decoder.token_embedding(input_ids)
-
+        
         # Concatenate image embeddings with token embeddings
         combined_embd = torch.cat((image_embd, token_embd), dim=1)
 
@@ -80,50 +68,38 @@ class VisionLanguageModel(nn.Module):
         # Adjust attention mask to account for image tokens
         if attention_mask is not None:
             # Create mask of 1s for image tokens (all image tokens should be attended to)
-            image_attention_mask = torch.ones(
-                (batch_size, img_seq_len),
-                device=attention_mask.device,
-                dtype=attention_mask.dtype,
-            )
+            image_attention_mask = torch.ones((batch_size, img_seq_len), device=attention_mask.device, dtype=attention_mask.dtype)
             attention_mask = torch.cat((image_attention_mask, attention_mask), dim=1)
-
+        
         # Generate from combined embeddings using the decoder
         # We need to use the decoder's forward function and not its generate method
         # because we want to keep track of the image prefix
         outputs = combined_embd
-        generated_tokens = torch.zeros(
-            (batch_size, max_new_tokens), device=input_ids.device, dtype=input_ids.dtype
-        )
-
-        # Note: Here you could implement improvements like e.g. KV caching
+        generated_tokens = torch.zeros((batch_size, max_new_tokens), device=input_ids.device, dtype=input_ids.dtype)
+        
+        #Note: Here you could implement improvements like e.g. KV caching
         for i in range(max_new_tokens):
             model_out = self.decoder(outputs, attention_mask)
-
+            
             # Get predictions for the last token only (normally this is the embedding, not the logits)
             last_token_logits = model_out[:, -1, :]
-
+            
             # Apply head to get logits (if model is in embedding mode)
             if not self.decoder.lm_use_tokens:
                 last_token_logits = self.decoder.head(last_token_logits)
 
             probs = torch.softmax(last_token_logits, dim=-1)
             next_token = torch.multinomial(probs, num_samples=1)
-
+                
             generated_tokens[:, i] = next_token.squeeze(-1)
-
+            
             # Convert to embedding and append
             next_embd = self.decoder.token_embedding(next_token)
             outputs = torch.cat((outputs, next_embd), dim=1)
 
             if attention_mask is not None:
-                attention_mask = torch.cat(
-                    (
-                        attention_mask,
-                        torch.ones((batch_size, 1), device=attention_mask.device),
-                    ),
-                    dim=1,
-                )
-
+                attention_mask = torch.cat((attention_mask, torch.ones((batch_size, 1), device=attention_mask.device)), dim=1)
+        
         return generated_tokens
 
     @classmethod

--- a/models/vision_language_model.py
+++ b/models/vision_language_model.py
@@ -1,7 +1,8 @@
-import os
 import json
+import os
 import tempfile
 from dataclasses import asdict
+from typing import Optional
 
 
 from models.vision_transformer import ViT
@@ -103,7 +104,9 @@ class VisionLanguageModel(nn.Module):
         return generated_tokens
 
     @classmethod
-    def from_pretrained(cls, repo_id_or_path: str) -> "VisionLanguageModel":
+    def from_pretrained(
+        cls, repo_id_or_path: str, *, revision: Optional[str] = None
+    ) -> "VisionLanguageModel":
         """
         Load a VisionLanguageModel from a local directory or a repo on the Hugging Face Hub.
 
@@ -131,10 +134,10 @@ class VisionLanguageModel(nn.Module):
             from huggingface_hub import hf_hub_download
 
             config_path = hf_hub_download(
-                repo_id=repo_id_or_path, filename="config.json"
+                repo_id=repo_id_or_path, filename="config.json", revision=revision
             )
             weights_path = hf_hub_download(
-                repo_id=repo_id_or_path, filename="model.safetensors"
+                repo_id=repo_id_or_path, filename="model.safetensors", revision=revision
             )
 
         # Load config

--- a/models/vision_language_model.py
+++ b/models/vision_language_model.py
@@ -139,7 +139,7 @@ class VisionLanguageModel(nn.Module):
 
         # Load config
         with open(config_path, "r") as f:
-            cfg = VLMConfig(**f.read())
+            cfg = VLMConfig(**json.load(f))
 
         # Initialize model
         model = cls(cfg)
@@ -164,7 +164,7 @@ class VisionLanguageModel(nn.Module):
 
         # Save config
         with open(os.path.join(save_directory, "config.json"), "w") as f:
-            f.write(json.dumps(asdict(self.cfg)))
+            f.write(json.dumps(asdict(self.cfg), indent=4))
 
         # Save weights as safetensors
         save_model(self, os.path.join(save_directory, "model.safetensors"))

--- a/models/vision_language_model.py
+++ b/models/vision_language_model.py
@@ -1,14 +1,21 @@
+import json
+import os
+import tempfile
+from dataclasses import asdict
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from safetensors.torch import load_model, save_model
 
+from models.config import VLMConfig
 from models.language_model import LanguageModel
 from models.modality_projector import ModalityProjector
 from models.vision_transformer import ViT
 
 
 class VisionLanguageModel(nn.Module):
-    def __init__(self, cfg):
+    def __init__(self, cfg: VLMConfig):
         super().__init__()
         self.cfg = cfg
         self.vision_encoder = ViT(cfg)
@@ -119,18 +126,129 @@ class VisionLanguageModel(nn.Module):
 
         return generated_tokens
 
-    def load_checkpoint(self, path):
-        print(f"Loading weights from full VLM checkpoint: {path}")
-        checkpoint = torch.load(
-            path,
-            map_location=torch.device("cuda" if torch.cuda.is_available() else "cpu"),
-        )
-        self.load_state_dict(checkpoint)
-
     @classmethod
-    def from_pretrained(cls, cfg):
+    def from_pretrained(cls, repo_id_or_path: str) -> "VisionLanguageModel":
+        """
+        Load a VisionLanguageModel from a local directory or a repo on the Hugging Face Hub.
+
+        Args:
+            repo_id_or_path (str): The path to the local directory or the Hugging Face Hub repo ID.
+
+        Returns:
+            VisionLanguageModel: The loaded model.
+        """
+        # If local folder exists => load from there
+        if os.path.exists(repo_id_or_path):
+            config_path = os.path.join(repo_id_or_path, "config.json")
+            weights_path = os.path.join(repo_id_or_path, "model.safetensors")
+
+            if not os.path.exists(config_path):
+                raise ValueError(
+                    f"Config file not found at {config_path}. Please provide a valid path."
+                )
+            if not os.path.exists(weights_path):
+                raise ValueError(
+                    f"Weights file not found at {weights_path}. Please provide a valid path."
+                )
+        # Otherwise, assume it's a Hugging Face Hub repo
+        else:
+            from huggingface_hub import hf_hub_download
+
+            config_path = hf_hub_download(
+                repo_id=repo_id_or_path, filename="config.json"
+            )
+            weights_path = hf_hub_download(
+                repo_id=repo_id_or_path, filename="model.safetensors"
+            )
+
+        # Load config
+        with open(config_path, "r") as f:
+            cfg = VLMConfig(**f.read())
+
+        # Initialize model
         model = cls(cfg)
         model.vision_encoder = ViT.from_pretrained(cfg)
         model.decoder = LanguageModel.from_pretrained(cfg)
 
+        # Load safetensors weights
+        load_model(model, weights_path)
+
+        # Done!
         return model
+
+    def save_pretrained(self, save_directory: str) -> None:
+        """
+        Save the model and configuration to a directory.
+
+        Args:
+            save_directory (str): The directory to save the model and config.
+        """
+        # Create directory if it doesn't exist
+        os.makedirs(save_directory, exist_ok=True)
+
+        # Save config
+        with open(os.path.join(save_directory, "config.json"), "w") as f:
+            f.write(json.dumps(asdict(self.cfg)))
+
+        # Save weights as safetensors
+        save_model(self, os.path.join(save_directory, "model.safetensors"))
+
+    def push_to_hub(self, repo_id: str, private: bool = False) -> None:
+        """
+        Push the model and configuration to the Hugging Face Hub.
+
+        Args:
+            repo_id (str): The repo ID on the Hugging Face Hub.
+        """
+        from huggingface_hub import create_repo, upload_folder
+
+        # Create repo
+        repo_url = create_repo(repo_id=repo_id, private=private, exist_ok=True)
+        repo_id = repo_url.repo_id
+        print("Created repo: ", repo_url)
+
+        with tempfile.TemporaryDirectory() as save_path:
+            # Save to tmp directory
+            self.save_pretrained(save_path)
+
+            # Save model card
+            with open(os.path.join(save_path, "README.md"), "w") as f:
+                f.write(MODEL_CARD_TEMPLATE.format(repo_id=repo_id))
+
+            # Upload
+            return upload_folder(
+                repo_id=repo_id,
+                repo_type="model",
+                folder_path=save_path,
+                commit_message="Upload nanoVLM using push_to_hub",
+            )
+
+
+MODEL_CARD_TEMPLATE = """
+---
+# For reference on model card metadata, see the spec: https://github.com/huggingface/hub-docs/blob/main/modelcard.md?plain=1
+# Doc / guide: https://huggingface.co/docs/hub/model-cards
+library_name: nanovlm
+license: mit
+pipeline_tag: image-text-to-text
+tags:
+  - vision-language
+  - multimodal
+  - research
+---
+
+**nanoVLM** is a minimal and lightweight Vision-Language Model (VLM) designed for efficient training and experimentation. Built using pure PyTorch, the entire model architecture and training logic fits within ~750 lines of code. It combines a ViT-based image encoder (SigLIP-B/16-224-85M) with a lightweight causal language model (SmolLM2-135M), resulting in a compact 222M parameter model.
+
+For more information, check out the base model on https://huggingface.co/lusxvr/nanoVLM-222M.
+
+**Usage:**
+
+Clone the nanoVLM repository: https://github.com/huggingface/nanoVLM.
+Follow the install instructions and run the following code:
+
+```python
+from models.vision_language_model import VisionLanguageModel
+
+model = VisionLanguageModel.from_pretrained("{repo_id}")
+```
+"""

--- a/models/vision_language_model.py
+++ b/models/vision_language_model.py
@@ -1,10 +1,11 @@
-from models.vision_transformer import ViT
-from models.language_model import LanguageModel
-from models.modality_projector import ModalityProjector
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+from models.language_model import LanguageModel
+from models.modality_projector import ModalityProjector
+from models.vision_transformer import ViT
+
 
 class VisionLanguageModel(nn.Module):
     def __init__(self, cfg):
@@ -20,26 +21,38 @@ class VisionLanguageModel(nn.Module):
 
         token_embd = self.decoder.token_embedding(input_ids)
 
-        combined_embd = torch.cat((image_embd, token_embd), dim=1) # Concatenate image embeddings to token embeddings
-        
+        combined_embd = torch.cat(
+            (image_embd, token_embd), dim=1
+        )  # Concatenate image embeddings to token embeddings
+
         # Adjust attention mask to account for image tokens
         if attention_mask is not None:
             # Create mask of 1s for image tokens (all image tokens should be attended to)
             batch_size = image_embd.size(0)
             img_seq_len = image_embd.size(1)
-            image_attention_mask = torch.ones((batch_size, img_seq_len), device=attention_mask.device, dtype=attention_mask.dtype)
-            
+            image_attention_mask = torch.ones(
+                (batch_size, img_seq_len),
+                device=attention_mask.device,
+                dtype=attention_mask.dtype,
+            )
+
             # Combine image and token attention masks
             attention_mask = torch.cat((image_attention_mask, attention_mask), dim=1)
 
-        logits = self.decoder(combined_embd, attention_mask) # Not logits yet, but easier to return like this
+        logits = self.decoder(
+            combined_embd, attention_mask
+        )  # Not logits yet, but easier to return like this
 
         loss = None
         if targets is not None:
             # Only use the token part of the logits for loss computation
             logits = self.decoder.head(logits)
-            logits = logits[:, image_embd.size(1):, :]
-            loss = F.cross_entropy(logits.reshape(-1, logits.size(-1)), targets.reshape(-1), ignore_index=-100)
+            logits = logits[:, image_embd.size(1) :, :]
+            loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)),
+                targets.reshape(-1),
+                ignore_index=-100,
+            )
 
         return logits, loss
 
@@ -48,10 +61,10 @@ class VisionLanguageModel(nn.Module):
         # Process image through vision encoder and projection
         image_embd = self.vision_encoder(image)
         image_embd = self.MP(image_embd)
-        
+
         # Embed initial tokens
         token_embd = self.decoder.token_embedding(input_ids)
-        
+
         # Concatenate image embeddings with token embeddings
         combined_embd = torch.cat((image_embd, token_embd), dim=1)
 
@@ -60,43 +73,58 @@ class VisionLanguageModel(nn.Module):
         # Adjust attention mask to account for image tokens
         if attention_mask is not None:
             # Create mask of 1s for image tokens (all image tokens should be attended to)
-            image_attention_mask = torch.ones((batch_size, img_seq_len), device=attention_mask.device, dtype=attention_mask.dtype)
+            image_attention_mask = torch.ones(
+                (batch_size, img_seq_len),
+                device=attention_mask.device,
+                dtype=attention_mask.dtype,
+            )
             attention_mask = torch.cat((image_attention_mask, attention_mask), dim=1)
-        
+
         # Generate from combined embeddings using the decoder
         # We need to use the decoder's forward function and not its generate method
         # because we want to keep track of the image prefix
         outputs = combined_embd
-        generated_tokens = torch.zeros((batch_size, max_new_tokens), device=input_ids.device, dtype=input_ids.dtype)
-        
-        #Note: Here you could implement improvements like e.g. KV caching
+        generated_tokens = torch.zeros(
+            (batch_size, max_new_tokens), device=input_ids.device, dtype=input_ids.dtype
+        )
+
+        # Note: Here you could implement improvements like e.g. KV caching
         for i in range(max_new_tokens):
             model_out = self.decoder(outputs, attention_mask)
-            
+
             # Get predictions for the last token only (normally this is the embedding, not the logits)
             last_token_logits = model_out[:, -1, :]
-            
+
             # Apply head to get logits (if model is in embedding mode)
             if not self.decoder.lm_use_tokens:
                 last_token_logits = self.decoder.head(last_token_logits)
 
             probs = torch.softmax(last_token_logits, dim=-1)
             next_token = torch.multinomial(probs, num_samples=1)
-                
+
             generated_tokens[:, i] = next_token.squeeze(-1)
-            
+
             # Convert to embedding and append
             next_embd = self.decoder.token_embedding(next_token)
             outputs = torch.cat((outputs, next_embd), dim=1)
 
             if attention_mask is not None:
-                attention_mask = torch.cat((attention_mask, torch.ones((batch_size, 1), device=attention_mask.device)), dim=1)
-        
+                attention_mask = torch.cat(
+                    (
+                        attention_mask,
+                        torch.ones((batch_size, 1), device=attention_mask.device),
+                    ),
+                    dim=1,
+                )
+
         return generated_tokens
-        
+
     def load_checkpoint(self, path):
         print(f"Loading weights from full VLM checkpoint: {path}")
-        checkpoint = torch.load(path, map_location=torch.device('cuda' if torch.cuda.is_available() else 'cpu'))        
+        checkpoint = torch.load(
+            path,
+            map_location=torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+        )
         self.load_state_dict(checkpoint)
 
     @classmethod


### PR DESCRIPTION
Inspired by https://github.com/huggingface/nanoVLM/pull/7 but using a vanilla integration (no mixin involved). 

## How to load

```py
from models.vision_language_model import VisionLanguageModel

model = VisionLanguageModel.from_pretrained("Wauplin/vanilla-nanovlm")
```

## How to save

```py
model.push_to_hub("Wauplin/vanilla-nanovlm-2")
```

The model will be saved to the Hub using safetensors. A basic model card is created referring to the main repo https://huggingface.co/lusxvr/nanoVLM-222M.  

---

I've also updated the `generate.py` and `README.md` files accordingly with new commands.

**TODO before merging:**
- [x] update `config.json` file in https://huggingface.co/lusxvr/nanoVLM-222M (copy [this one](https://huggingface.co/Wauplin/vanilla-nanovlm/blob/main/config.json))
- [x] add `model.safetensors` in https://huggingface.co/lusxvr/nanoVLM-222M (copy [this one](https://huggingface.co/Wauplin/vanilla-nanovlm/blob/main/model.safetensors))
- [ ] delete https://huggingface.co/lusxvr/nanoVLM-222M/blob/main/nanoVLM-222M.pth

=> all done by merging https://huggingface.co/lusxvr/nanoVLM-222M/discussions/1