### PR TITLE
fix padding and completion-only collation

### DIFF
--- a/data/collators.py
+++ b/data/collators.py
@@ -21,7 +21,7 @@ class VQACollator(object):  # Visual Question Answering Collator
         encoded_full_sequences = self.tokenizer.batch_encode_plus(
             input_sequences,
             padding="max_length",
-            padding_side="left",
+            padding_side="right",
             return_tensors="pt",
             truncation=True,
             max_length=self.max_length,
@@ -35,7 +35,7 @@ class VQACollator(object):  # Visual Question Answering Collator
         labels[:, -1] = -100 #self.tokenizer.pad_token_id
 
         # The tokenizer has different behavior for padding and truncation:
-        # 1. If the full text (answer + question) is shorter than the max length, its gets padded on the left
+        # 1. If the full text (answer + question) is shorter than the max length, its gets padded on the right
         # 2. If the full text is longer than the max length, it gets truncated on the right
         # Therefore, I need to handle multipe cases, this is the different scenarios:
         # If the full text is longer than the max lenght, we need to set the labels to -100 for the whole sample (we want to ignore the whole sample)
@@ -56,14 +56,15 @@ class VQACollator(object):  # Visual Question Answering Collator
                 continue
             
             # Case 2: Sequence fits within max_length
-            # Use attention mask to find first non-padding token
-            # The first 1 in the attention mask marks the first non-padding token
-            first_token_pos = attention_mask[i].nonzero(as_tuple=True)[0][0].item()
-            
-            # Set labels for padding and question part to -100 (don't predict these), substracting 1 to account for the left shift
-            question_end = first_token_pos + question_length - 1 
+            # Set labels for question part to -100 (don't predict these), substracting 1 to account for the left shift
+            question_end = question_length - 1 
             labels[i, :question_end] = -100
 
+            # use input_ids to find where the eos_token is, we'll mask everything after that
+            # as the extra eos_tokens after the final eos_token act as pad tokens.
+            eos_token_pos = torch.where(input_ids[i]==0)[0][0].item()
+            labels[i, eos_token_pos:] = -100
+            
         return {
             "image": images,
             "input_ids": input_ids,
@@ -86,14 +87,14 @@ class MMStarCollator(object):  # https://huggingface.co/datasets/Lin-Chen/MMStar
         encoded_question_sequences = self.tokenizer.batch_encode_plus(
             questions,
             padding=True,
-            padding_side="left",
+            padding_side="right",
             return_tensors="pt"
         )
 
         encoded_answer_sequences = self.tokenizer.batch_encode_plus(
             answers,
             padding=True,
-            padding_side="left",
+            padding_side="right",
             return_tensors="pt"
         )
         


### PR DESCRIPTION
updates as per #29 

- update padding_side to 'right'
- change completion only data collation to mask the pad tokens in the right

example:

```py
sample['input_ids'][0]

tensor([17872,    42, 15232,    42, 10181,   260,  8223,   338, 11046,  1114,
          429,   260,   777, 28876,   288,   260,  7145,    30,   198, 29943,
          943,    42,   198,    49,    30, 40743,  3773,    30,   198,    50,
           30,  5969,    30,   198,    51,    30, 23949,    30,   198,    52,
           30,  4388,    30,   198, 21350,   351,   260,  4386,    30, 19842,
           42,   216, 19842,    42,   340,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0,     0,     0,     0])
```
```py
sample['labels'][0]

tensor([ -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,
         -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,
         -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,
         -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,
         -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,
         -100, 19842,    42,   340,     0,  -100,  -100,  -100,  -100,  -100,
         -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,
         -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100,  -100])
```

decoded input_ids:
```
Question: Question: Name the tube that carries food from the pharynx to the stomach.
Choices:
A. uvula.
B. liver.
C. esophagus.
D. mouth.
Answer with the letter. Answer:  Answer: C<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>
```
decoded labels:
```py
tokenizer.decode([19842,    42,   340,     0])
' Answer: C<|endoftext|>'
```