### PR TITLE
Add DeepSeek-style RotaryEmbedding with frequency correction

### DIFF
--- a/models/config.py
+++ b/models/config.py
@@ -28,6 +28,9 @@ class VLMConfig:
     lm_max_length: int = 128 - 49  # Deduct the image token lenght to achieve a 'nice number'
     lm_use_tokens: bool = False # Decide if the LM expects tokens or embeddings as input (if using as a backbone for the VLM, set to False)
     lm_tie_weights: bool = True # Decide if you want to tie the LM Head weight to the token embeding weights
+    lm_rope_factor: float = 0.7
+    lm_beta_fast: int = 32
+    lm_beta_slow: int = 1
     lm_model_type: str = 'HuggingFaceTB/SmolLM2-135M'
     lm_tokenizer: str = 'HuggingFaceTB/cosmo2-tokenizer'
     lm_eos_token_id: int = 0


### PR DESCRIPTION
This PR adds a custom RotaryEmbedding variant inspired by DeepSeek-V3.

Key features:
- Dynamic inverse frequency scaling based on sequence length
- Linear ramping applied in the frequency space
- Mitigates RoPE periodicity for long-context generalization
- Drop-in compatible with the existing embedding structure

Tested and verified on synthetic inputs. Ready for further benchmarking.
