### PR TITLE
Fix wandb logging conditional for accuracy in training

### DIFF
--- a/train.py
+++ b/train.py
@@ -333,7 +333,8 @@ def train(train_cfg, vlm_cfg):
                         if epoch_accuracy > best_accuracy:
                             best_accuracy = epoch_accuracy
                             eval_model.save_pretrained(save_directory=vlm_cfg.vlm_checkpoint_path)
-                        run.log({"accuracy": epoch_accuracy}, step=global_step)
+                        if train_cfg.log_wandb:
+                            run.log({"accuracy": epoch_accuracy}, step=global_step)
                         print(f"Step: {global_step}, Loss: {batch_loss:.4f}, Tokens/s: {tokens_per_second:.2f}, Accuracy: {epoch_accuracy:.4f}")
                     elif is_master() and not global_step % (train_cfg.eval_interval*4) == 0:
                         print(f"Step: {global_step}, Loss: {batch_loss:.4f}, Tokens/s: {tokens_per_second:.2f}")


### PR DESCRIPTION
This pull request fixes an issue in `train.py` where training accuracy was being logged to Weights & Biases (WandB) even when `train_cfg.log_wandb` was set to `False`.

The logging of accuracy to WandB is now correctly conditional upon the `train_cfg.log_wandb` setting, preventing unintended logging.

### Corrected Behavior:

* [`train.py`](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R336): Ensured that accuracy is logged to WandB only if `train_cfg.log_wandb` is explicitly enabled in the training configuration.