### PR TITLE
Add gradient clipping

### DIFF
--- a/models/config.py
+++ b/models/config.py
@@ -50,6 +50,7 @@ class TrainConfig:
     batch_size: int = 256
     gradient_accumulation_steps: int = 1
     mmstar_batch_size: int = 32
+    max_grad_norm: float = None
     eval_in_epochs: bool = True
     eval_interval: int = 250
     epochs: int = 5


### PR DESCRIPTION
I added an option to enable gradient clipping. It made training more stable in my experiments, especially when using smaller batch sizes.

You can see the effect in these logs (purple = with gradient clipping, green = without).
![grad_clip](https://github.com/user-attachments/assets/f7164785-23f6-4f01-a719-a50e4052bc50)

It's disabled by default and can be enabled by setting `max_grad_norm` in `config.py`