### PR TITLE
Add self_attention.py to Implement SelfAttentionLayer for Self-Attention Architecture

### DIFF
--- a/models/self_attention.py
+++ b/models/self_attention.py
@@ -1,0 +1,94 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class SelfAttentionLayer(nn.Module):
+    def __init__(self, embed_dim: int, num_heads: int, dropout: float = 0.1, pre_norm: bool = True, return_attn_weights: bool = False):
+        """
+        A configurable Transformer-style self-attention block supporting Pre-LN and Post-LN.
+
+        Args:
+            embed_dim (int): Dimension of the embeddings.
+            num_heads (int): Number of attention heads.
+            dropout (float): Dropout rate for attention and FFN.
+            pre_norm (bool): If True, uses Pre-LayerNorm. If False, uses Post-LayerNorm.
+            return_attn_weights (bool): If True, returns attention weights.
+        """
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.pre_norm = pre_norm
+        self.return_attn_weights = return_attn_weights
+
+        # Multi-head self-attention
+        self.attn = nn.MultiheadAttention(embed_dim, num_heads, dropout=dropout, batch_first=True)
+
+        # LayerNorm layers
+        self.attn_norm = nn.LayerNorm(embed_dim)
+        self.ffn_norm = nn.LayerNorm(embed_dim)
+
+        # Dropout
+        self.dropout = nn.Dropout(dropout)
+
+        # Feed-forward network (position-wise MLP)
+        self.ffn = nn.Sequential(
+            nn.Linear(embed_dim, embed_dim * 4),
+            nn.GELU(),
+            nn.Linear(embed_dim * 4, embed_dim),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, x, attention_mask=None):
+        """
+        Forward pass for the self-attention layer.
+
+        Args:
+            x (Tensor): Input tensor of shape [batch_size, seq_len, embed_dim].
+            attention_mask (Tensor or None): Binary mask (1 for valid tokens, 0 for padding).
+
+        Returns:
+            Tensor: Output tensor of shape [batch_size, seq_len, embed_dim].
+        """
+        key_padding_mask = None
+        if attention_mask is not None:
+            # Convert to key_padding_mask for PyTorch MHA: True = ignore
+            key_padding_mask = (attention_mask == 0)
+
+        if self.pre_norm:
+            # --- Pre-LayerNorm Variant ---
+            residual = x
+            x_norm = self.attn_norm(x)
+            attn_out, attn_weights = self.attn(
+                query=x_norm,
+                key=x_norm,
+                value=x_norm,
+                key_padding_mask=key_padding_mask,
+                need_weights=self.return_attn_weights
+            )
+            x = residual + self.dropout(attn_out)
+
+            residual = x
+            x_norm = self.ffn_norm(x)
+            ffn_out = self.ffn(x_norm)
+            x = residual + ffn_out
+
+        else:
+            # --- Post-LayerNorm Variant ---
+            residual = x
+            attn_out, attn_weights = self.attn(
+                query=x,
+                key=x,
+                value=x,
+                key_padding_mask=key_padding_mask,
+                need_weights=self.return_attn_weights
+            )
+            x = self.attn_norm(residual + self.dropout(attn_out))
+
+            residual = x
+            ffn_out = self.ffn(x)
+            x = self.ffn_norm(residual + ffn_out)
+
+        if self.return_attn_weights:
+            return x, attn_weights
+        return x


### PR DESCRIPTION
I saw a comment from @andimarafioti  in [[this GitHub issue](https://github.com/huggingface/nanoVLM/issues/83)](https://github.com/huggingface/nanoVLM/issues/83) where they mentioned wanting to add a self-attention architecture to the project. Based on that, I created a new file `self_attention.py` and added a class `SelfAttentionLayer` that implements a configurable self-attention mechanism.

In the class, I included the option to choose between **Pre-LayerNorm** and **Post-LayerNorm** styles. The layer also supports dropout for regularization and can handle attention masks for padding tokens.

### **Changes**:

* Added `self_attention.py` with the `SelfAttentionLayer` class.
* The layer is flexible: it can use **Pre-LayerNorm** or **Post-LayerNorm**, depending on the `pre_norm` parameter.
* Attention masking support is included to handle padding tokens (e.g., in sequences).
* Dropout is also supported to help prevent overfitting.

### **Example Code**:

```python
from models.self_attention import SelfAttentionLayer

# Pre-Norm self-attention
attention_layer = SelfAttentionLayer(embed_dim=768, num_heads=12, pre_norm=True)

# Post-Norm self-attention
attention_layer_post = SelfAttentionLayer(embed_dim=768, num_heads=12, pre_norm=False)
```

### **Why This Change**:

I created this addition to help improve and experiment with the self-attention architecture. The goal is to provide a more modular and flexible self-attention layer that can easily be integrated into existing models. The `pre_norm` flag allows us to test both common normalization styles (Pre-LayerNorm vs. Post-LayerNorm) and make the model more adaptable.

### **Next Steps**:

* Please review the code in `self_attention.py`. Since I’m still learning about machine learning, any feedback on errors or potential improvements would be greatly appreciated! I’m contributing to open-source to learn and improve my skills in this area.

Also, I used ChatGPT to help write this PR so that it’s easier to read and more clear.

