### PR TITLE
Perf: Adding torch.compile + static cache, ~3x speed up

### DIFF
--- a/benchmark-inference.py
+++ b/benchmark-inference.py
@@ -11,31 +11,43 @@ from data.processors import get_tokenizer, get_image_processor
 from torch.utils import benchmark
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-print(f"Using device: {device}")
+dtype = torch.float16
+use_torch_compile = False
+
+print(f"Using device: {device} with dtype: {dtype}")
 
 def generate_tokens(tokens, image):
+    
     gen = model.generate(tokens, image, max_new_tokens=1000)
 
+
 if __name__ == "__main__":
-    model = VisionLanguageModel.from_pretrained("lusxvr/nanoVLM-222M").to(device)
+    model = VisionLanguageModel.from_pretrained("lusxvr/nanoVLM-222M").to(device, dtype)
     model.eval()
-    
+
     tokenizer = get_tokenizer(model.cfg.lm_tokenizer)
     image_processor = get_image_processor(model.cfg.vit_img_size)
 
     text = "What is this?"
     template = f"Question: {text} Answer:"
     encoded_batch = tokenizer.batch_encode_plus([template], return_tensors="pt")
-    tokens = encoded_batch['input_ids'].to(device)
+    tokens = encoded_batch["input_ids"].to(device)
 
-    image_path = 'assets/image.png'
+    image_path = "assets/image.png"
     image = Image.open(image_path)
     image = image_processor(image)
-    image = image.unsqueeze(0).to(device)
+    image = image.unsqueeze(0).to(device, dtype)
+
+    if use_torch_compile:
+        model.decoder = torch.compile(model.decoder, mode="reduce-overhead", fullgraph=True)
+
+    # Warmup
+    for i in range(3):
+        _ = model.generate(tokens, image, max_new_tokens=128)
 
     time = benchmark.Timer(
         stmt="generate_tokens(tokens, image)",
-        setup='from __main__ import generate_tokens',
+        setup="from __main__ import generate_tokens",
         globals={"tokens": tokens, "image": image},
         num_threads=torch.get_num_threads(),
     )

--- a/models/kvcache.py
+++ b/models/kvcache.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 
 
+# Copy from https://github.com/pytorch-labs/gpt-fast/blob/7dd5661e2adf2edd6a1042a2732dcd3a94064ad8/mixtral-moe/model.py#L58
 class KVCache(nn.Module):
     def __init__(self, max_batch_size, max_seq_length, n_heads, head_dim, dtype=torch.bfloat16):
         super().__init__()

--- a/models/kvcache.py
+++ b/models/kvcache.py
@@ -1,0 +1,27 @@
+import torch
+import torch.nn as nn
+
+
+class KVCache(nn.Module):
+    def __init__(self, max_batch_size, max_seq_length, n_heads, head_dim, dtype=torch.bfloat16):
+        super().__init__()
+        cache_shape = (max_batch_size, n_heads, max_seq_length, head_dim)
+        self.register_buffer('k_cache', torch.zeros(cache_shape, dtype=dtype))
+        self.register_buffer('v_cache', torch.zeros(cache_shape, dtype=dtype))
+
+    @classmethod
+    def new(cls, max_batch_size, max_seq_length, n_heads, head_dim, dtype=torch.bfloat16):
+        return cls(max_batch_size, max_seq_length, n_heads, head_dim, dtype)
+
+    def update(self, input_pos, k_val, v_val):
+        # input_pos: [S], k_val: [B, H, S, D]
+
+        assert input_pos.shape[0] == k_val.shape[2]
+
+        k_out = self.k_cache
+        v_out = self.v_cache
+
+        k_out[:, :, input_pos] = k_val
+        v_out[:, :, input_pos] = v_val
+
+        return k_out, v_out

--- a/models/language_model.py
+++ b/models/language_model.py
@@ -258,15 +258,13 @@ class LanguageModel(nn.Module):
         elif isinstance(module, RMSNorm):
             module.weight.data.fill_(1.0)
 
-    def forward(self, x, attention_mask=None, kv_cache=None, start_pos=0):
+    def forward(self, x, attention_mask=None, kv_cache=None, current_position_ids: torch.Tensor = None):
         if self.lm_use_tokens:
             x = self.token_embedding(x)
 
         # T_curr is the length of the current input sequence
-        B, T_curr, _ = x.size()
-        
         # Create position_ids for the current sequence based on start_pos
-        current_position_ids = torch.arange(start_pos, start_pos + T_curr, device=x.device).unsqueeze(0).expand(B, -1)
+
         cos, sin = self.rotary_embd(current_position_ids) # Get rotary position embeddings for current tokens
 
         # Initialize new KV cache if none provided
@@ -279,8 +277,8 @@ class LanguageModel(nn.Module):
         x = self.norm(x)
 
         # Compute logits if we are using tokens, otherwise stay in the embedding space
-        if self.lm_use_tokens: 
-            x = self.head(x) 
+        if self.lm_use_tokens:
+            x = self.head(x)
 
         return x, kv_cache
 

--- a/models/language_model.py
+++ b/models/language_model.py
@@ -1,7 +1,10 @@
 import math
+from typing import List
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from models.kvcache import KVCache
 
 # https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L69
 class RMSNorm(nn.Module):
@@ -37,16 +40,20 @@ class RotaryEmbedding(nn.Module):
     def forward(self, position_ids):
         batch_size, seq_len = position_ids.shape
         # Dynamic scaling for longer sequences
+        
+        # (tsdocode, 28 May 2025) 
+        # if else cause: Dynamic control flow is not supported at the moment.
+        # Refactor using torch.clamp
         max_seq = position_ids.max() + 1
-        if max_seq > self.original_max_seq_len:
-            scale = max_seq / self.original_max_seq_len
-            inv_freq = self.inv_freq / scale
-        else:
-            inv_freq = self.inv_freq
+        
+        scale = torch.clamp(max_seq / self.original_max_seq_len, min=1.0)
+        inv_freq = self.inv_freq / scale
             
         # Compute theta = position * frequency
         # Flatten position_ids for batch processing
-        flat_position_ids = position_ids.reshape(-1).float()
+        # (tsdocode, 28 May 2025) 
+        # Fix dtype error on bfloat16/float16 inference
+        flat_position_ids = position_ids.reshape(-1).to(self.inv_freq.dtype)
         
         # Element-wise outer product: [seq_len] x [dim/2] => [seq_len, dim/2]
         freqs = flat_position_ids.unsqueeze(-1) * inv_freq.unsqueeze(0)
@@ -112,10 +119,8 @@ class LanguageModelGroupedQueryAttention(nn.Module):
         if not self.sdpa:
             print("Warning: scaled dot product attention not available, using standard attention in LM.")
 
-    def forward(self, x, cos, sin, attention_mask=None, block_kv_cache=None):
-        is_prefill = block_kv_cache is None
-
-        B, T_curr, C = x.size() # T_curr is the sequence length of the current input x
+    def forward(self, x, cos, sin, attention_mask=None, block_kv_cache=None, current_position_ids=None):
+        B, T_curr, C = x.size()  # T_curr is the sequence length of the current input x
 
         q_curr = self.q_proj(x).view(B, T_curr, self.n_heads, self.head_dim).transpose(1, 2)  # (B, n_heads, T_curr, head_dim)
         k_curr = self.k_proj(x).view(B, T_curr, self.n_kv_heads, self.head_dim).transpose(1, 2) # (B, n_kv_heads, T_curr, head_dim)
@@ -124,21 +129,9 @@ class LanguageModelGroupedQueryAttention(nn.Module):
         # Apply rotary embeddings to the current q and k
         q, k_rotated = apply_rotary_pos_embd(q_curr, k_curr, cos, sin)
 
-        # Check if we can use cached keys and values
-        if not is_prefill and block_kv_cache['key'] is not None:
-            # Concatenate with cached K, V
-            # k_rotated and v_curr are for the new token(s)
-            k = block_kv_cache['key']
-            v = block_kv_cache['value']
-            k = torch.cat([k, k_rotated], dim=2)
-            v = torch.cat([v, v_curr], dim=2)
-            block_kv_cache['key'] = k
-            block_kv_cache['value'] = v
-        else:
-            # No cache, this is the first pass (prefill)
-            k = k_rotated
-            v = v_curr
-            block_kv_cache = {'key': k, 'value': v}
+        # (tsdocode, 28 May 2025)
+        # Simplify kv cache update KV cache
+        k, v = block_kv_cache.update(current_position_ids[0], k_rotated, v_curr)
 
         # Repeat K, V for Grouped Query Attention
         k_exp = k.repeat_interleave(self.n_kv_groups, dim=1) # (B, n_heads, T_kv, head_dim)
@@ -153,7 +146,8 @@ class LanguageModelGroupedQueryAttention(nn.Module):
             # The current `attention_mask` parameter is assumed to be `[B, total_sequence_length_kv]`
             # Let's make it `[B, 1, 1, T_kv]` for SDPA.
             mask_for_keys = attention_mask[:, :T_kv] # Ensure mask matches key length [B, T_kv]
-            additive_attn_mask = (1.0 - mask_for_keys.unsqueeze(1).unsqueeze(2).float()) * torch.finfo(q.dtype).min
+            # attention mask is already in [B, 1, 1, T_kv]
+            additive_attn_mask = (1.0 - mask_for_keys.to(k.dtype)) * torch.finfo(q.dtype).min
             # This additive_attn_mask shape is [B, 1, 1, T_kv]
 
         if self.sdpa and x.device.type != 'mps':
@@ -161,7 +155,7 @@ class LanguageModelGroupedQueryAttention(nn.Module):
             is_causal = (T_curr == T_kv and T_curr > 1)
             y = torch.nn.functional.scaled_dot_product_attention(
                 q, k_exp, v_exp,
-                attn_mask=additive_attn_mask, 
+                attn_mask=additive_attn_mask,
                 dropout_p=self.dropout if self.training else 0.0,
                 is_causal=is_causal
             )
@@ -185,7 +179,7 @@ class LanguageModelGroupedQueryAttention(nn.Module):
         y = self.out_proj(y)
         y = self.resid_dropout(y)
 
-        return y, block_kv_cache
+        return y
 
 # https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L160
 class LanguageModelMLP(nn.Module):
@@ -206,6 +200,7 @@ class LanguageModelMLP(nn.Module):
 
         return x
 
+
 # https://github.com/meta-llama/llama3/blob/main/llama/model.py#L222
 class LanguageModelBlock(nn.Module):
     def __init__(self, cfg):
@@ -215,10 +210,10 @@ class LanguageModelBlock(nn.Module):
         self.norm1 = RMSNorm(cfg) # Input Norm
         self.norm2 = RMSNorm(cfg) # Post Attention Norm
     
-    def forward(self, x, cos, sin, attention_mask=None, block_kv_cache=None):
+    def forward(self, x, cos, sin, attention_mask=None, block_kv_cache=None, current_position_ids=None):
         res = x
         x = self.norm1(x)
-        x, block_kv_cache = self.attn(x, cos, sin, attention_mask, block_kv_cache)
+        x = self.attn(x, cos, sin, attention_mask, block_kv_cache, current_position_ids)
         x = res + x
 
         res = x
@@ -226,7 +221,8 @@ class LanguageModelBlock(nn.Module):
         x = self.mlp(x)
         x = res + x
 
-        return x, block_kv_cache
+        return x
+
 
 # https://github.com/meta-llama/llama3/blob/main/llama/model.py#L251
 class LanguageModel(nn.Module):
@@ -258,7 +254,7 @@ class LanguageModel(nn.Module):
         elif isinstance(module, RMSNorm):
             module.weight.data.fill_(1.0)
 
-    def forward(self, x, attention_mask=None, kv_cache=None, current_position_ids: torch.Tensor = None):
+    def forward(self, x, attention_mask=None, kv_cache: Optional[List[KVCache]] = None, current_position_ids: torch.Tensor = None):
         if self.lm_use_tokens:
             x = self.token_embedding(x)
 
@@ -267,12 +263,20 @@ class LanguageModel(nn.Module):
 
         cos, sin = self.rotary_embd(current_position_ids) # Get rotary position embeddings for current tokens
 
-        # Initialize new KV cache if none provided
+        # # Initialize new KV cache if none provided
         if kv_cache is None:
-            kv_cache = [None] * len(self.blocks)
+            kv_cache = [
+                KVCache.new(
+                    max_batch_size=x.shape[0],
+                    max_seq_length=self.cfg.lm_max_position_embeddings,
+                    n_heads=self.cfg.lm_n_heads,
+                    head_dim=self.cfg.lm_hidden_dim // self.cfg.lm_n_heads,
+                    dtype=x.dtype
+                )
+            ] * len(self.blocks)
 
         for i, block in enumerate(self.blocks):
-            x, kv_cache[i] = block(x, cos, sin, attention_mask, kv_cache[i])
+            x = block(x, cos, sin, attention_mask, kv_cache[i], current_position_ids)
 
         x = self.norm(x)
 

--- a/models/language_model.py
+++ b/models/language_model.py
@@ -1,5 +1,5 @@
 import math
-from typing import List
+from typing import List, Optional
 
 import torch
 import torch.nn as nn
@@ -152,12 +152,12 @@ class LanguageModelGroupedQueryAttention(nn.Module):
 
         if self.sdpa and x.device.type != 'mps':
             # During decode, no additional masking needed as [1, T_kv] is naturally causal
-            is_causal = (T_curr == T_kv and T_curr > 1)
+            # Fix: torch._dynamo.exc.Unsupported: TypeError <built-in function scaled_dot_product_attention>: scaled_dot_product_attention(): argument 'is_causal' must be bool, not SymBool
             y = torch.nn.functional.scaled_dot_product_attention(
                 q, k_exp, v_exp,
                 attn_mask=additive_attn_mask,
                 dropout_p=self.dropout if self.training else 0.0,
-                is_causal=is_causal
+                is_causal=False
             )
         else:
             # Manual attention implementation


### PR DESCRIPTION
Did:
- Add Static KVCache from gpt-fast
- Adjust logic to use new KV Cache
- Fix code for torch.compile compatible

Result on A100 for 1000 tokens:
Overall:
**~x2.6 faster for fp32
~x3.2 faster for fp16**


```
Branch main: Using device: cuda
<torch.utils.benchmark.utils.common.Measurement object at 0x7f2b05192c50>
generate_tokens(tokens, image)
setup: from __main__ import generate_tokens
  23.38 s
  1 measurement, 10 runs , 24 threads   
Using device: cuda with dtype: torch.float32, torch.compile: False
<torch.utils.benchmark.utils.common.Measurement object at 0x7f8015c3df90>
generate_tokens(tokens, image)
setup: from __main__ import generate_tokens
  26.81 s
  1 measurement, 10 runs , 24 threads

Using device: cuda with dtype: torch.float32,  torch.compile: True
setup: from __main__ import generate_tokens
  9.97 s
  1 measurement, 10 runs , 24 threads


Using device: cuda with dtype: torch.float16, torch.compile: False
<torch.utils.benchmark.utils.common.Measurement object at 0x7f7c70058310>
generate_tokens(tokens, image)
setup: from __main__ import generate_tokens
  26.65 s
  1 measurement, 10 runs , 24 threads


Using device: cuda with dtype: torch.float16, torch.compile: True
<torch.utils.benchmark.utils.common.Measurement object at 0x7fe84850edd0>
generate_tokens(tokens, image)
setup: from __main__ import generate_tokens
  7.84 s
  1 measurement, 10 runs , 24 threads
```


TODO:
- Adjust code for compatible with previous KVCache
- Check training compatible