### PR TITLE
Feat: adding torch.is_grad_enabled() argument to implement KV cache only during inference

### DIFF
--- a/models/language_model.py
+++ b/models/language_model.py
@@ -125,7 +125,7 @@ class LanguageModelGroupedQueryAttention(nn.Module):
         q, k_rotated = apply_rotary_pos_embd(q_curr, k_curr, cos, sin)
 
         # update KV cache only during inference
-        if not self.training:
+        if not torch.is_grad_enabled():
             # Check if we can use cached keys and values
             if not is_prefill and block_kv_cache['key'] is not None:
                 # Concatenate with cached K, V

--- a/models/language_model.py
+++ b/models/language_model.py
@@ -124,21 +124,26 @@ class LanguageModelGroupedQueryAttention(nn.Module):
         # Apply rotary embeddings to the current q and k
         q, k_rotated = apply_rotary_pos_embd(q_curr, k_curr, cos, sin)
 
-        # Check if we can use cached keys and values
-        if not is_prefill and block_kv_cache['key'] is not None:
-            # Concatenate with cached K, V
-            # k_rotated and v_curr are for the new token(s)
-            k = block_kv_cache['key']
-            v = block_kv_cache['value']
-            k = torch.cat([k, k_rotated], dim=2)
-            v = torch.cat([v, v_curr], dim=2)
-            block_kv_cache['key'] = k
-            block_kv_cache['value'] = v
+        # update KV cache only during inference
+        if not self.training:
+            # Check if we can use cached keys and values
+            if not is_prefill and block_kv_cache['key'] is not None:
+                # Concatenate with cached K, V
+                # k_rotated and v_curr are for the new token(s)
+                k = block_kv_cache['key']
+                v = block_kv_cache['value']
+                k = torch.cat([k, k_rotated], dim=2)
+                v = torch.cat([v, v_curr], dim=2)
+                block_kv_cache['key'] = k
+                block_kv_cache['value'] = v
+            else:
+                # No cache, this is the first pass (prefill)
+                k = k_rotated
+                v = v_curr
+                block_kv_cache = {'key': k, 'value': v}
         else:
-            # No cache, this is the first pass (prefill)
             k = k_rotated
             v = v_curr
-            block_kv_cache = {'key': k, 'value': v}
 
         # Repeat K, V for Grouped Query Attention
         k_exp = k.repeat_interleave(self.n_kv_groups, dim=1) # (B, n_heads, T_kv, head_dim)


### PR DESCRIPTION
Resolving issue https://github.com/huggingface/nanoVLM/issues/92

Added torch.is_grad_enabled() argument in language_model.py to populate KV cache only during inference and set it [None] during training and validation.

- This keeps the code cleaner and easy to understand compared to adding additional arguments in call functions
- using self.training argument is not the perfect solution as it will populate KV cache during validation when model.eval() is called
- torch.is_grad_enabled() is better because it handles validation when torch.no_grad() is set and inference when torch.inference_mode() is set