### PR TITLE
Fix Typo in nanoVLM.ipynb

### DIFF
--- a/nanoVLM.ipynb
+++ b/nanoVLM.ipynb
@@ -64,7 +64,7 @@
       },
       "outputs": [],
       "source": [
-        "# If you get an \"Error\" from pip's dependency resolver but the cell complets fine, this is not an issue, you can continue :)\n",
+        "# If you get an \"Error\" from pip's dependency resolver but the cell completes fine, this is not an issue, you can continue :)\n",
         "!pip -q install torch\n",
         "!pip -q install gcsfs\n",
         "!pip -q install datasets==3.5.0\n",


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the nanoVLM.ipynb notebook. The word "complets" has been changed to "completes" in the comment regarding pip's dependency resolver errors. No other changes were made. This update improves the clarity and professionalism of the notebook's instructions.