### PR TITLE
Fix typo in comment: "concatinated" → "concatenated"

### DIFF
--- a/nanoVLM.ipynb
+++ b/nanoVLM.ipynb
@@ -180,7 +180,7 @@
         "    train_ds = concatenate_datasets(combined_train_data)\n",
         "    \n",
         "    test_ds = load_dataset(train_cfg.test_dataset_path)\n",
-        "    train_ds = train_ds.shuffle(seed=0) # Shuffle the training dataset, so train and val get equal contributions from all concatinated datasets\n",
+        "    train_ds = train_ds.shuffle(seed=0) # Shuffle the training dataset, so train and val get equal contributions from all concatenated datasets\n",
         "\n",
         "    # Apply cutoff if specified\n",
         "    if train_cfg.data_cutoff_idx is None:\n",


### PR DESCRIPTION


**Description:**  
This pull request fixes a typo in a comment within the code. The word "concatinated" has been corrected to "concatenated" to improve clarity and maintain code quality. No functional changes were made.