### PR TITLE
Packing

### DIFF
--- a/data/advanced_datasets.py
+++ b/data/advanced_datasets.py
@@ -4,7 +4,7 @@ import threading
 from queue import Queue
 from typing import Iterator
 import itertools
-
+import random
 
 class ConstantLengthDataset(IterableDataset):
     def __init__(
@@ -209,6 +209,7 @@ class ConstantLengthDataset(IterableDataset):
             knapsack_image_counts[suitable_knapsack] += item_image_count
 
         # remove the completely empty bags that the +delta heuristic created
+        random.shuffle(knapsack_groups)  # Knapsacks are semi-ordered after packing, thanks Luis for noticing!
         return [g for g in knapsack_groups if g]
 
     def _pack_one_group(self, group_indices, batch, max_len):

--- a/data/advanced_datasets.py
+++ b/data/advanced_datasets.py
@@ -1,0 +1,157 @@
+import torch
+from torch.utils.data import IterableDataset, get_worker_info
+import threading
+from queue import Queue
+from typing import Iterator
+import itertools
+
+
+class ConstantLengthDataset(IterableDataset):
+    def __init__(
+        self,
+        dataset, infinite: bool = False, seq_length: int = 1024, num_of_sequences: int = 1024, queue_size: int = 2048,
+    ):
+        self.dataset = dataset
+        self.seq_length = seq_length
+        self.max_length = seq_length * num_of_sequences
+        self.epoch = 0  # only advanced when infinite=True
+        self.infinite = infinite
+        self.queue_size = queue_size
+        self._sentinel = object()
+
+    def __len__(self):
+        return int(len(self.dataset) * 256/self.seq_length)
+
+    def __iter__(self) -> Iterator[dict]:
+        """
+        Returns a consumer iterator that drains `self._queue`.
+        A background thread keeps that queue topped up.
+        """
+        worker_info = get_worker_info()
+        worker_id = worker_info.id if worker_info else 0
+        num_workers = worker_info.num_workers if worker_info else 1
+
+        def make_base_iterator():
+            """Return a (sharded) iterator over the underlying dataset."""
+            all_indices = range(len(self.dataset))
+
+            # Shard the *indices* first, before any data is fetched.
+            if num_workers > 1:
+                worker_indices = itertools.islice(all_indices, worker_id, None, num_workers)
+            else:
+                worker_indices = all_indices
+
+            # Create an iterator that only calls __getitem__ for the assigned indices.
+            def sharded_item_iterator():
+                for idx in worker_indices:
+                    yield self.dataset[idx]
+
+            return sharded_item_iterator()        
+        
+        queue: Queue = Queue(maxsize=self.queue_size)
+
+        producer = threading.Thread(
+            target=self._producer, args=(make_base_iterator, queue), daemon=True
+        )
+        producer.start()
+
+        while True:
+            sample = queue.get()
+            if sample is self._sentinel:
+                break
+            yield sample
+
+    def _producer(
+            self,
+            make_iterator,  # a zero-arg lambda that returns a fresh (possibly sharded) iterator
+            queue: Queue,
+        ):
+        """Runs in a separate daemon thread and keeps `queue` full."""
+        iterator = make_iterator()
+        more_examples = True
+
+        while more_examples:
+            # ------------- 1) pull raw samples until we have enough -------- #
+            buffer, buffer_len = [], 0
+            while buffer_len < self.max_length:
+                try:
+                    sample = next(iterator)
+                except StopIteration:
+                    if self.infinite:
+                        iterator = make_iterator()
+                        self.epoch += 1
+                        print(f"Epoch {self.epoch} finished, restarting iterator")
+                        continue
+                    else:
+                        more_examples = False
+                        break
+
+                if len(sample["input_ids"]) > self.seq_length:
+                    continue  # skip overly long samples
+
+                buffer.append(sample)
+                buffer_len += len(sample["input_ids"])
+
+            if not buffer:
+                break  # nothing left and not infinite
+
+            # ------------- 2) run greedy knapsack & pack groups ------------ #
+            lengths = [len(x["input_ids"]) for x in buffer]
+            groups = self._balanced_greedy_knapsack(lengths, self.seq_length, delta=5)
+
+            for g in groups:
+                packed = self._pack_one_group(g, buffer, self.seq_length)
+
+                # put blocks if queue is full.
+                queue.put(
+                    {
+                        "input_ids": packed[0],
+                        "labels": packed[1],
+                        "attention_mask": packed[2],
+                        "images": packed[3],
+                    }
+                )
+
+        # finished → unblock consumer
+        queue.put(self._sentinel)
+
+    def _balanced_greedy_knapsack(self, lengths, L, delta=0):
+        # keep the position while sorting
+        items = sorted(enumerate(lengths), key=lambda x: x[1], reverse=True)
+
+        min_knapsacks   = (sum(lengths) + L - 1) // L + delta
+        knapsack_load   = [0]   * min_knapsacks
+        knapsack_groups = [[] for _ in range(min_knapsacks)]
+
+        for idx, item_len in items:
+            # choose the lightest knapsack so far
+            ks_id = min(range(len(knapsack_load)),
+                        key=knapsack_load.__getitem__)
+
+            # open a new one if the chosen bag would overflow
+            if knapsack_load[ks_id] + item_len > L:
+                ks_id = len(knapsack_load)
+                knapsack_load   .append(0)
+                knapsack_groups.append([])
+
+            knapsack_groups[ks_id].append(idx)
+            knapsack_load  [ks_id] += item_len
+
+        # remove the completely empty bags that the +delta heuristic created
+        return [g for g in knapsack_groups if g]
+
+    def _pack_one_group(self, group_indices, batch,
+                        max_len):
+        ids, lbl, am, ims = [], [], [], []
+
+        for i in group_indices:
+            ids.extend(batch[i]["input_ids"])
+            lbl.extend(batch[i]["labels"])
+            am .extend(batch[i]["attention_mask"])
+            ims.extend(batch[i]["images"])
+
+        # safety: assert we never overflow
+        if len(ids) > max_len:
+            raise ValueError(f"Packed length {len(ids)} > max_len {max_len}")
+
+        return torch.stack(ids), torch.stack(lbl), torch.stack(am), ims

--- a/data/advanced_datasets.py
+++ b/data/advanced_datasets.py
@@ -31,8 +31,8 @@ class ConstantLengthDataset(IterableDataset):
         self.max_images_per_knapsack = max_images_per_knapsack
         self._sentinel = object()
         self._average_length_per_sample = (
-            self.dataset.mp_image_token_length + 367
-        )  # 367 is the average tokens for the cauldron dataset
+            self.dataset.mp_image_token_length + 198
+        )  # 198 is the average tokens for the cauldron dataset
 
     def __len__(self):
         return int(

--- a/data/advanced_datasets.py
+++ b/data/advanced_datasets.py
@@ -9,9 +9,14 @@ import itertools
 class ConstantLengthDataset(IterableDataset):
     def __init__(
         self,
-        dataset, infinite: bool = False, max_sample_length: int = 1024,
-        seq_length: int = 1024, num_of_sequences: int = 1024, queue_size: int = 2048, max_images_per_example: int = 4,
-        max_images_per_knapsack: int = 18
+        dataset,
+        infinite: bool = False,
+        max_sample_length: int = 1024,
+        seq_length: int = 1024,
+        num_of_sequences: int = 1024,
+        queue_size: int = 2048,
+        max_images_per_example: int = 4,
+        max_images_per_knapsack: int = 18,
     ):
         self.dataset = dataset
         self.max_sample_length = max_sample_length
@@ -23,16 +28,19 @@ class ConstantLengthDataset(IterableDataset):
         self.max_images_per_example = max_images_per_example
         self.max_images_per_knapsack = max_images_per_knapsack
         self._sentinel = object()
-        self._average_length_per_sample = self.dataset.mp_image_token_length + 367 # 367 is the average tokens for the cauldron dataset
-
+        self._average_length_per_sample = (
+            self.dataset.mp_image_token_length + 367
+        )  # 367 is the average tokens for the cauldron dataset
 
     def __len__(self):
-        return int(len(self.dataset) * self._average_length_per_sample/self.seq_length)
+        return int(
+            len(self.dataset) * self._average_length_per_sample / self.seq_length
+        )
 
     def __iter__(self) -> Iterator[dict]:
         """
         Returns an iterator over the dataset that yields fixed-length sequences for training.
-        
+
         The iterator uses a producer-consumer pattern with a background thread to efficiently
         pre-fetch and buffer samples. The producer thread continuously reads from the base
         dataset and fills a queue, while the main thread consumes from the queue.
@@ -42,7 +50,7 @@ class ConstantLengthDataset(IterableDataset):
         Returns:
             Iterator[dict]: An iterator that yields training samples with the following structure:
                 - input_ids: Tensor of token ids of shape (seq_length,)
-                - labels: Tensor of labels of shape (seq_length,) 
+                - labels: Tensor of labels of shape (seq_length,)
                 - attention_mask: Tensor of attention mask of shape (seq_length,)
                 - images: List of processed image tensors
         """
@@ -56,7 +64,9 @@ class ConstantLengthDataset(IterableDataset):
 
             # Shard the *indices* first, before any data is fetched.
             if num_workers > 1:
-                worker_indices = itertools.islice(all_indices, worker_id, None, num_workers)
+                worker_indices = itertools.islice(
+                    all_indices, worker_id, None, num_workers
+                )
             else:
                 worker_indices = all_indices
 
@@ -65,8 +75,8 @@ class ConstantLengthDataset(IterableDataset):
                 for idx in worker_indices:
                     yield self.dataset[idx]
 
-            return sharded_item_iterator()        
-        
+            return sharded_item_iterator()
+
         queue: Queue = Queue(maxsize=self.queue_size)
 
         producer = threading.Thread(
@@ -81,10 +91,10 @@ class ConstantLengthDataset(IterableDataset):
             yield sample
 
     def _producer(
-            self,
-            make_iterator,  # a zero-arg lambda that returns a fresh (possibly sharded) iterator
-            queue: Queue,
-        ):
+        self,
+        make_iterator,  # a zero-arg lambda that returns a fresh (possibly sharded) iterator
+        queue: Queue,
+    ):
         """Runs in a separate daemon thread and keeps `queue` full."""
         iterator = make_iterator()
         more_examples = True
@@ -110,8 +120,15 @@ class ConstantLengthDataset(IterableDataset):
                 if len(sample["images"]) > self.max_images_per_example:
                     continue  # skip samples that exceed the image constraint
 
-                sample["input_ids"] = torch.cat([sample["input_ids"], torch.tensor([self.dataset.tokenizer.pad_token_id])])
-                sample["attention_mask"] = torch.cat([sample["attention_mask"], torch.tensor([0])])
+                sample["input_ids"] = torch.cat(
+                    [
+                        sample["input_ids"],
+                        torch.tensor([self.dataset.tokenizer.pad_token_id]),
+                    ]
+                )
+                sample["attention_mask"] = torch.cat(
+                    [sample["attention_mask"], torch.tensor([0])]
+                )
                 sample["labels"] = torch.cat([sample["labels"], torch.tensor([-100])])
 
                 buffer.append(sample)
@@ -121,7 +138,12 @@ class ConstantLengthDataset(IterableDataset):
                 break  # nothing left and not infinite
 
             # ------------- 2) run greedy knapsack & pack groups ------------ #
-            groups = self._balanced_greedy_knapsack(buffer, self.seq_length, delta=5, max_images_per_knapsack=self.max_images_per_knapsack)
+            groups = self._balanced_greedy_knapsack(
+                buffer,
+                self.seq_length,
+                delta=5,
+                max_images_per_knapsack=self.max_images_per_knapsack,
+            )
 
             for g in groups:
                 packed = self._pack_one_group(g, buffer, self.seq_length)
@@ -139,33 +161,42 @@ class ConstantLengthDataset(IterableDataset):
         # finished → unblock consumer
         queue.put(self._sentinel)
 
-    def _balanced_greedy_knapsack(self, buffer, L, delta=0, max_images_per_knapsack=None):
+    def _balanced_greedy_knapsack(
+        self, buffer, L, delta=0, max_images_per_knapsack=None
+    ):
         # Extract lengths and image counts from buffer
         lengths = [len(x["input_ids"]) for x in buffer]
         image_counts = [len(x["images"]) for x in buffer]
-        
-        # keep the position while sorting
-        items = sorted(enumerate(zip(lengths, image_counts)), key=lambda x: x[1][0], reverse=True)
 
-        min_knapsacks   = (sum(lengths) + L - 1) // L + delta
-        knapsack_load   = [0]   * min_knapsacks
+        # keep the position while sorting
+        items = sorted(
+            enumerate(zip(lengths, image_counts)), key=lambda x: x[1][0], reverse=True
+        )
+
+        min_knapsacks = (sum(lengths) + L - 1) // L + delta
+        knapsack_load = [0] * min_knapsacks
         knapsack_image_counts = [0] * min_knapsacks
         knapsack_groups = [[] for _ in range(min_knapsacks)]
 
         for idx, (item_len, item_image_count) in items:
             # Find a suitable knapsack that satisfies both length and image count constraints
             suitable_knapsack = None
-            
+
             # First try to find a knapsack that can fit both constraints
-            for ks_id in sorted(range(len(knapsack_load)), key=knapsack_load.__getitem__):
+            for ks_id in sorted(
+                range(len(knapsack_load)), key=knapsack_load.__getitem__
+            ):
                 length_fits = knapsack_load[ks_id] + item_len <= L
-                image_fits = (max_images_per_knapsack is None or 
-                             knapsack_image_counts[ks_id] + item_image_count <= max_images_per_knapsack)
-                
+                image_fits = (
+                    max_images_per_knapsack is None
+                    or knapsack_image_counts[ks_id] + item_image_count
+                    <= max_images_per_knapsack
+                )
+
                 if length_fits and image_fits:
                     suitable_knapsack = ks_id
                     break
-            
+
             # If no existing knapsack can fit, create a new one
             if suitable_knapsack is None:
                 suitable_knapsack = len(knapsack_load)
@@ -180,14 +211,13 @@ class ConstantLengthDataset(IterableDataset):
         # remove the completely empty bags that the +delta heuristic created
         return [g for g in knapsack_groups if g]
 
-    def _pack_one_group(self, group_indices, batch,
-                        max_len):
+    def _pack_one_group(self, group_indices, batch, max_len):
         ids, lbl, am, ims = [], [], [], []
 
         for i in group_indices:
             ids.extend(batch[i]["input_ids"])
             lbl.extend(batch[i]["labels"])
-            am .extend(batch[i]["attention_mask"])
+            am.extend(batch[i]["attention_mask"])
             ims.extend(batch[i]["images"])
 
         # safety: assert we never overflow

--- a/data/advanced_datasets.py
+++ b/data/advanced_datasets.py
@@ -6,6 +6,8 @@ from typing import Iterator
 import itertools
 import random
 
+random.seed(42)  # Set the random seed to the meaning of life for good luck
+
 class ConstantLengthDataset(IterableDataset):
     def __init__(
         self,

--- a/data/collators.py
+++ b/data/collators.py
@@ -19,7 +19,7 @@ class BaseCollator(object):
         else:
             max_len = max(map(len, batch["input_ids"]))
         batch["input_ids"] = [torch.nn.functional.pad(ids, (max_len - len(ids), 0), value=self.tokenizer.pad_token_id) for ids in batch["input_ids"]]
-        batch["labels"]    = [torch.nn.functional.pad(l, (max_len - len(l), 0), value=0) for l in batch["labels"]]
+        batch["labels"]    = [torch.nn.functional.pad(l, (max_len - len(l), 0), value=self.tokenizer.pad_token_id) for l in batch["labels"]]
         batch["attention_mask"] = [torch.nn.functional.pad(a, (max_len - len(a), 0), value=0) for a in batch["attention_mask"]]
 
         return {

--- a/data/collators.py
+++ b/data/collators.py
@@ -9,55 +9,110 @@ class BaseCollator(object):
         random_string_location = random_string_chat_templated.find(random_string_5_letters)
 
         self.prefix_len = len(self.tokenizer.encode(random_string_chat_templated[:random_string_location]))
-    
-    def prepare_inputs_and_loss_mask(self, batched_messages, max_length=None):
-        batch_token_ids: list[list[int]] = []
-        batch_masks:     list[list[int]] = []
-        batch_attentions: list[list[int]] = []
 
-        for messages in batched_messages:
-            conv_ids = self.tokenizer.apply_chat_template(
-                    messages,
-                    tokenize=True,
-                    add_special_tokens=False,
-                    return_dict=True,
+    def _balanced_greedy_knapsack(self, lengths, L, delta=0):
+        # keep the position while sorting
+        items = sorted(enumerate(lengths), key=lambda x: x[1], reverse=True)
+
+        min_knapsacks   = (sum(lengths) + L - 1) // L + delta
+        knapsack_load   = [0]   * min_knapsacks
+        knapsack_groups = [[] for _ in range(min_knapsacks)]
+
+        for idx, item_len in items:
+            # choose the lightest knapsack so far
+            ks_id = min(range(len(knapsack_load)),
+                        key=knapsack_load.__getitem__)
+
+            # open a new one if the chosen bag would overflow
+            if knapsack_load[ks_id] + item_len > L:
+                ks_id = len(knapsack_load)
+                knapsack_load   .append(0)
+                knapsack_groups.append([])
+
+            knapsack_groups[ks_id].append(idx)
+            knapsack_load  [ks_id] += item_len
+
+        # remove the completely empty bags that the +delta heuristic created
+        return [g for g in knapsack_groups if g]
+
+    def _pack_one_group(self, group_indices, batch,
+                        max_len):
+        ids, lbl, am, ims = [], [], [], []
+
+        for i in group_indices:
+            ids.extend(batch["input_ids"][i])
+            lbl.extend(batch["labels"][i])
+            am .extend(batch["attention_mask"][i])
+            ims.extend(batch["images"][i])
+
+        # safety: assert we never overflow
+        if len(ids) > max_len:
+            raise ValueError(f"Packed length {len(ids)} > max_len {max_len}")
+
+        return torch.stack(ids), torch.stack(lbl), torch.stack(am), ims
+
+    def prepare_batch(self, batch, max_length=None, packing=False):
+        # batch is a list of dicts, each containing "input_ids", "attention_mask", "labels", "images"
+        # let's convert it to a dict of lists of tensors
+        batch = {k: [item[k] for item in batch] for k in batch[0]}
+
+        if max_length is not None:
+            batch = self._discard_samples_that_are_too_long(batch, max_length)
+
+        if packing:
+            if max_length is None:
+                raise ValueError("max_length must be provided when packing is True")
+            
+            # 1) run knapsack on the lengths
+            lengths = list(map(len, batch["input_ids"]))
+            groups  = self._balanced_greedy_knapsack(lengths, max_length)
+
+            # 2) build new (packed) lists
+            packed_ids, packed_lbl, packed_am, packed_imgs = [], [], [], []
+
+            for g in groups:
+                ids, lbl, am, ims = self._pack_one_group(
+                    g, batch, max_length
                 )
-            mask = [0] * len(conv_ids["input_ids"])
+                packed_ids .append(ids)
+                packed_lbl .append(lbl)
+                packed_am  .append(am)
+                packed_imgs.append(ims)
+            #Flatten images again
+            # packed_imgs = [img for sublist in packed_imgs for img in sublist]
 
-            # Locate each assistant turn and flip its mask to 1
-            cursor = 0
-            for msg in messages:
-                segment_ids = self.tokenizer.apply_chat_template(
-                    [msg], tokenize=True, add_special_tokens=False
-                )
-                seg_len = len(segment_ids)
-
-                if msg["role"] == "assistant":
-                    start = cursor + self.prefix_len
-                    end   = cursor + seg_len
-                    mask[start:end] = [1] * (end - start)  # attend to these tokens
-
-                cursor += seg_len
-
-            batch_token_ids.append(conv_ids["input_ids"])
-            batch_masks.append(mask)
-            batch_attentions.append(conv_ids["attention_mask"])
-
-        if max_length is not None:  # We need to keep the tokens to allow for the img embed replacing logic to work. Otherwise, we would need to track which images correspond to long samples.
-            batch_token_ids = [ids[:max_length] for ids in batch_token_ids]
-            batch_masks = [m if len(m) <= max_length else [0]*max_length for m in batch_masks] # Ignore samples that are longer than max_length
-            batch_attentions = [a[:max_length] for a in batch_attentions]
-
+            batch["input_ids"] = packed_ids
+            batch["labels"]    = packed_lbl
+            batch["attention_mask"]= packed_am
+            batch["images"]    = packed_imgs
+        
         # Pad samples to max length
         if max_length is not None:
             max_len = max_length
         else:
-            max_len = max(map(len, batch_token_ids))
-        batch_token_ids = [[self.tokenizer.pad_token_id]*(max_len-len(ids)) + ids for ids in batch_token_ids]
-        batch_masks     = [[0]*(max_len-len(m)) + m         for m   in batch_masks]
-        batch_attentions = [[0]*(max_len-len(a)) + a         for a   in batch_attentions]
+            max_len = max(map(len, batch["input_ids"]))
+        batch["input_ids"] = [torch.nn.functional.pad(ids, (max_len - len(ids), 0), value=self.tokenizer.pad_token_id) for ids in batch["input_ids"]]
+        batch["labels"]    = [torch.nn.functional.pad(l, (max_len - len(l), 0), value=0) for l in batch["labels"]]
+        batch["attention_mask"] = [torch.nn.functional.pad(a, (max_len - len(a), 0), value=0) for a in batch["attention_mask"]]
 
-        return torch.tensor(batch_token_ids), torch.tensor(batch_attentions), torch.tensor(batch_masks).to(torch.bool)
+        return {
+            "input_ids": torch.stack(batch["input_ids"]),
+            "attention_mask": torch.stack(batch["attention_mask"]),
+            "images": batch["images"],
+            "labels": torch.stack(batch["labels"]),
+        }
+
+    def _discard_samples_that_are_too_long(self, batch, max_length):
+        filtered = [
+            (ids, label, attn, img)
+            for ids, label, attn, img in zip(batch["input_ids"], batch["labels"], batch["attention_mask"], batch["images"])
+            if len(ids) <= max_length
+        ]
+        if not filtered:
+            return [], [], [], []
+        batch_token_ids, batch_labels, batch_attentions, batch_images = zip(*filtered)
+        return {"input_ids": list(batch_token_ids), "labels": list(batch_labels), "attention_mask": list(batch_attentions), "images": list(batch_images)}
+
 
 class VQACollator(BaseCollator):  # Visual Question Answering Collator
     def __init__(self, tokenizer, max_length):
@@ -65,48 +120,75 @@ class VQACollator(BaseCollator):  # Visual Question Answering Collator
         super().__init__(tokenizer)
 
     def __call__(self, batch):
-        images = [item["images"] for item in batch]
-        messages_batched = [item["text_data"] for item in batch]
-
-        # Stack images
-        imgs = [img for sublist in images for img in sublist]
-        images = torch.stack(imgs)
-
-        # Create inputs by concatenating special image tokens, question, and answer
-        batch_input_ids, batch_attention_mask, loss_masks = self.prepare_inputs_and_loss_mask(messages_batched, max_length=self.max_length)
-
-        # Create labels where only answer tokens are predicted
-        labels = batch_input_ids.clone().masked_fill(~loss_masks, -100)
-        labels[:, :-1] = labels[:, 1:] # Shift labels for causal LM
-        labels[:, -1] = -100 # Last token has no target
-
-        return {
-            "image": images,
-            "input_ids": batch_input_ids,
-            "attention_mask": batch_attention_mask,
-            "labels": labels,
-        }
+        batch = self.prepare_batch(batch, max_length=self.max_length, packing=True)
+        return batch
 
 class MMStarCollator(BaseCollator):  # https://huggingface.co/datasets/Lin-Chen/MMStar
-    def __init__(self, tokenizer):
-        super().__init__(tokenizer)
-    
     def __call__(self, batch):
-        images = [item["image"] for item in batch]
-        messages_batched = [item["text_data"] for item in batch]
+        batch = self.prepare_batch(batch)
+        return batch
 
-        # Stack images
-        images = torch.stack(images)
-        # Create inputs by concatenating special image tokens, question, and answer
-        batch_input_ids, batch_attention_mask, loss_masks = self.prepare_inputs_and_loss_mask(messages_batched)
+class Buffer:
+    def __init__(self):
+        self.examples: list[dict] = []
 
-        input_ids = batch_input_ids.masked_fill(loss_masks, self.tokenizer.pad_token_id)
-        attention_mask = batch_attention_mask.masked_fill(loss_masks, 0)
-        labels = batch_input_ids.clone().masked_fill(~loss_masks, self.tokenizer.pad_token_id)
+    def __len__(self):
+        return len(self.examples)
 
-        return {
-            "images": images,
-            "input_ids": input_ids,
-            "attention_mask": attention_mask,
-            "labels": labels,
-        }
+    def take(self, n: int) -> list[dict]:
+        out, self.examples = self.examples[:n], self.examples[n:]
+        return out
+
+    def extend(self, xs: list[dict]) -> None:
+        self.examples.extend(xs)
+
+class BufferedCollator:
+    def __init__(self,
+                 inner_collator,
+                 target_batch_size: int,
+                 max_buffer: int | None = None):
+        self.inner = inner_collator
+        self.N = target_batch_size
+        self.max_buffer = (
+            max_buffer if max_buffer is not None
+            else 4 * target_batch_size
+        )
+        self.buffer = Buffer()
+
+    def __call__(self, dataset_batch):
+        batch = self.inner(dataset_batch)
+        packed_size = len(batch["input_ids"])
+
+        if packed_size > self.N:
+            keep, overflow = (
+                {k: v[:self.N] for k, v in batch.items()},
+                {k: v[self.N:] for k, v in batch.items()},
+            )
+            self.buffer.extend([
+                {"images": img, "input_ids": ids, "attention_mask": attn, "labels": lbl}
+                for img, ids, attn, lbl in zip(overflow["images"], overflow["input_ids"], overflow["attention_mask"], overflow["labels"])
+            ])
+            batch = keep
+            packed_size = self.N
+
+        if packed_size < self.N and len(self.buffer) > 0:
+            extra_samples = self.buffer.take(self.N - packed_size)
+            extra_batch = {}
+            keys = extra_samples[0].keys()
+            for k in keys:
+                values = [d[k] for d in extra_samples]
+                if k == 'images':
+                    extra_batch[k] = values
+                else:
+                    extra_batch[k] = torch.stack(values, dim=0)
+
+            # Merge the extra batch with the current batch
+            for k in batch:
+                if k == 'images':
+                    batch[k].extend(extra_batch[k])
+                else:
+                    batch[k] = torch.cat([batch[k], extra_batch[k]], dim=0)
+                
+            packed_size = len(batch["input_ids"])
+
+        return batch

--- a/data/collators.py
+++ b/data/collators.py
@@ -4,54 +4,8 @@ import torch
 class BaseCollator(object):
     def __init__(self, tokenizer):
         self.tokenizer = tokenizer
-        random_string_5_letters = "xzyvd"
-        random_string_chat_templated = self.tokenizer.apply_chat_template([{"role": "assistant", "content": random_string_5_letters}], tokenize=False, add_special_tokens=False)
-        random_string_location = random_string_chat_templated.find(random_string_5_letters)
 
-        self.prefix_len = len(self.tokenizer.encode(random_string_chat_templated[:random_string_location]))
-
-    def _balanced_greedy_knapsack(self, lengths, L, delta=0):
-        # keep the position while sorting
-        items = sorted(enumerate(lengths), key=lambda x: x[1], reverse=True)
-
-        min_knapsacks   = (sum(lengths) + L - 1) // L + delta
-        knapsack_load   = [0]   * min_knapsacks
-        knapsack_groups = [[] for _ in range(min_knapsacks)]
-
-        for idx, item_len in items:
-            # choose the lightest knapsack so far
-            ks_id = min(range(len(knapsack_load)),
-                        key=knapsack_load.__getitem__)
-
-            # open a new one if the chosen bag would overflow
-            if knapsack_load[ks_id] + item_len > L:
-                ks_id = len(knapsack_load)
-                knapsack_load   .append(0)
-                knapsack_groups.append([])
-
-            knapsack_groups[ks_id].append(idx)
-            knapsack_load  [ks_id] += item_len
-
-        # remove the completely empty bags that the +delta heuristic created
-        return [g for g in knapsack_groups if g]
-
-    def _pack_one_group(self, group_indices, batch,
-                        max_len):
-        ids, lbl, am, ims = [], [], [], []
-
-        for i in group_indices:
-            ids.extend(batch["input_ids"][i])
-            lbl.extend(batch["labels"][i])
-            am .extend(batch["attention_mask"][i])
-            ims.extend(batch["images"][i])
-
-        # safety: assert we never overflow
-        if len(ids) > max_len:
-            raise ValueError(f"Packed length {len(ids)} > max_len {max_len}")
-
-        return torch.stack(ids), torch.stack(lbl), torch.stack(am), ims
-
-    def prepare_batch(self, batch, max_length=None, packing=False):
+    def prepare_batch(self, batch, max_length=None):
         # batch is a list of dicts, each containing "input_ids", "attention_mask", "labels", "images"
         # let's convert it to a dict of lists of tensors
         batch = {k: [item[k] for item in batch] for k in batch[0]}
@@ -59,33 +13,6 @@ class BaseCollator(object):
         if max_length is not None:
             batch = self._discard_samples_that_are_too_long(batch, max_length)
 
-        if packing:
-            if max_length is None:
-                raise ValueError("max_length must be provided when packing is True")
-            
-            # 1) run knapsack on the lengths
-            lengths = list(map(len, batch["input_ids"]))
-            groups  = self._balanced_greedy_knapsack(lengths, max_length)
-
-            # 2) build new (packed) lists
-            packed_ids, packed_lbl, packed_am, packed_imgs = [], [], [], []
-
-            for g in groups:
-                ids, lbl, am, ims = self._pack_one_group(
-                    g, batch, max_length
-                )
-                packed_ids .append(ids)
-                packed_lbl .append(lbl)
-                packed_am  .append(am)
-                packed_imgs.append(ims)
-            #Flatten images again
-            # packed_imgs = [img for sublist in packed_imgs for img in sublist]
-
-            batch["input_ids"] = packed_ids
-            batch["labels"]    = packed_lbl
-            batch["attention_mask"]= packed_am
-            batch["images"]    = packed_imgs
-        
         # Pad samples to max length
         if max_length is not None:
             max_len = max_length
@@ -120,75 +47,10 @@ class VQACollator(BaseCollator):  # Visual Question Answering Collator
         super().__init__(tokenizer)
 
     def __call__(self, batch):
-        batch = self.prepare_batch(batch, max_length=self.max_length, packing=True)
+        batch = self.prepare_batch(batch, max_length=self.max_length)
         return batch
 
 class MMStarCollator(BaseCollator):  # https://huggingface.co/datasets/Lin-Chen/MMStar
     def __call__(self, batch):
         batch = self.prepare_batch(batch)
-        return batch
-
-class Buffer:
-    def __init__(self):
-        self.examples: list[dict] = []
-
-    def __len__(self):
-        return len(self.examples)
-
-    def take(self, n: int) -> list[dict]:
-        out, self.examples = self.examples[:n], self.examples[n:]
-        return out
-
-    def extend(self, xs: list[dict]) -> None:
-        self.examples.extend(xs)
-
-class BufferedCollator:
-    def __init__(self,
-                 inner_collator,
-                 target_batch_size: int,
-                 max_buffer: int | None = None):
-        self.inner = inner_collator
-        self.N = target_batch_size
-        self.max_buffer = (
-            max_buffer if max_buffer is not None
-            else 4 * target_batch_size
-        )
-        self.buffer = Buffer()
-
-    def __call__(self, dataset_batch):
-        batch = self.inner(dataset_batch)
-        packed_size = len(batch["input_ids"])
-
-        if packed_size > self.N:
-            keep, overflow = (
-                {k: v[:self.N] for k, v in batch.items()},
-                {k: v[self.N:] for k, v in batch.items()},
-            )
-            self.buffer.extend([
-                {"images": img, "input_ids": ids, "attention_mask": attn, "labels": lbl}
-                for img, ids, attn, lbl in zip(overflow["images"], overflow["input_ids"], overflow["attention_mask"], overflow["labels"])
-            ])
-            batch = keep
-            packed_size = self.N
-
-        if packed_size < self.N and len(self.buffer) > 0:
-            extra_samples = self.buffer.take(self.N - packed_size)
-            extra_batch = {}
-            keys = extra_samples[0].keys()
-            for k in keys:
-                values = [d[k] for d in extra_samples]
-                if k == 'images':
-                    extra_batch[k] = values
-                else:
-                    extra_batch[k] = torch.stack(values, dim=0)
-
-            # Merge the extra batch with the current batch
-            for k in batch:
-                if k == 'images':
-                    batch[k].extend(extra_batch[k])
-                else:
-                    batch[k] = torch.cat([batch[k], extra_batch[k]], dim=0)
-                
-            packed_size = len(batch["input_ids"])
-
         return batch

--- a/data/collators.py
+++ b/data/collators.py
@@ -7,8 +7,8 @@ class BaseCollator(object):
 
     def _pad_batch(self, batch, max_length):
         batch["input_ids"] = [torch.nn.functional.pad(ids, (max_length - len(ids), 0), value=self.tokenizer.pad_token_id) for ids in batch["input_ids"]]
-        batch["labels"]    = [torch.nn.functional.pad(l, (max_length - len(l), 0), value=self.tokenizer.pad_token_id) for l in batch["labels"]]
-        batch["attention_mask"] = [torch.nn.functional.pad(a, (max_length - len(a), 0), value=0) for a in batch["attention_mask"]]
+        batch["labels"]    = [torch.nn.functional.pad(labels, (max_length - len(labels), 0), value=self.tokenizer.pad_token_id) for labels in batch["labels"]]
+        batch["attention_mask"] = [torch.nn.functional.pad(attention_mask, (max_length - len(attention_mask), 0), value=0) for attention_mask in batch["attention_mask"]]
 
     def prepare_batch(self, batch, max_length=None):
         # batch is a list of dicts, each containing "input_ids", "attention_mask", "labels", "images"
@@ -51,8 +51,8 @@ class VQACollator(BaseCollator):  # Visual Question Answering Collator
 
     def _pad_batch(self, batch, max_length):  # Reimplementing to use -100 as the pad value for labels, so that it's ignored by the loss
         batch["input_ids"] = [torch.nn.functional.pad(ids, (max_length - len(ids), 0), value=self.tokenizer.pad_token_id) for ids in batch["input_ids"]]
-        batch["labels"]    = [torch.nn.functional.pad(l, (max_length - len(l), 0), value=-100) for l in batch["labels"]]
-        batch["attention_mask"] = [torch.nn.functional.pad(a, (max_length - len(a), 0), value=0) for a in batch["attention_mask"]]
+        batch["labels"]    = [torch.nn.functional.pad(labels, (max_length - len(labels), 0), value=-100) for labels in batch["labels"]]
+        batch["attention_mask"] = [torch.nn.functional.pad(attention_mask, (max_length - len(attention_mask), 0), value=0) for attention_mask in batch["attention_mask"]]
 
     def __call__(self, batch):
         batch = self.prepare_batch(batch, max_length=self.max_length)

--- a/data/data_utils.py
+++ b/data/data_utils.py
@@ -1,0 +1,35 @@
+import torch
+import torch.distributed as dist
+
+
+def synchronized_dataloader_step(train_loader, is_dist):
+    """
+    Create a synchronized iterator that handles uneven data distribution in DDP.
+    All ranks will stop when the first rank runs out of data.
+    This happens because when packing a presharded dataset, a rank might have less groups than the others.
+    """
+    if not is_dist:
+        # For single GPU, we don't need synchronization.
+        for batch in train_loader:
+            yield batch
+        return
+    
+    # For DDP, we need synchronization.
+    train_iter = iter(train_loader)
+    
+    while True:
+        try:
+            batch = next(train_iter)
+            has_data = torch.tensor(1, device=torch.cuda.current_device())
+        except StopIteration:
+            batch = None
+            has_data = torch.tensor(0, device=torch.cuda.current_device())
+        
+        # We synchronize across all ranks. If any rank is out of data, all ranks stop.
+        dist.all_reduce(has_data, op=dist.ReduceOp.MIN)
+        
+        if has_data.item() == 0:
+            # At least one rank is out of data. All ranks should stop.
+            break
+        yield batch
+    return None

--- a/data/datasets.py
+++ b/data/datasets.py
@@ -1,16 +1,16 @@
 import torch
 from PIL import Image
-from torch.utils.data import Dataset
-
-import models.config as cfg
+from torch.utils.data import Dataset, IterableDataset
 
 
 class BaseDataset(Dataset):
-    def __init__(self, dataset, tokenizer, image_processor, mp_image_token_length):
+    def __init__(self, dataset, tokenizer, image_processor, mp_image_token_length, rank=0, num_replicas=1):
         self.dataset = dataset
         self.tokenizer = tokenizer
         self.image_processor = image_processor
         self.mp_image_token_length = mp_image_token_length
+        self.rank = rank
+        self.num_replicas = num_replicas
 
         self.prefix_len = self._get_prefix_len()
 
@@ -22,6 +22,30 @@ class BaseDataset(Dataset):
         random_string_chat_templated = self.tokenizer.apply_chat_template([{"role": "assistant", "content": random_string_5_letters}], tokenize=False, add_special_tokens=False)
         random_string_location = random_string_chat_templated.find(random_string_5_letters)
         return len(self.tokenizer.encode(random_string_chat_templated[:random_string_location]))
+
+    def _get_messages(self, item, image_count=0):
+        messages = []
+        for text in item['texts']:
+            messages.append({"role": "user", "content": text['user']})
+            messages.append({"role": "assistant", "content": text['assistant']})
+
+        if image_count > 0:
+            messages[0]["content"] = self.tokenizer.image_token * image_count * self.mp_image_token_length + messages[0]["content"]      
+
+        return messages
+
+    def _process_images(self, images):
+        processed_images = []
+        for image in images:
+            if isinstance(image, Image.Image):
+                if image.mode != 'RGB':
+                    image = image.convert('RGB')
+                processed_image = self.image_processor(image)
+                processed_images.append(processed_image)
+            else:
+                raise ValueError(f"Error processing image")
+        return processed_images
+
 
     def _prepare_inputs_and_loss_mask(self, messages):
         conv_ids = self.tokenizer.apply_chat_template(
@@ -51,9 +75,6 @@ class BaseDataset(Dataset):
 
 
 class VQADataset(BaseDataset):  # Visual Question Answering Dataset
-    def __init__(self, dataset, tokenizer, image_processor, mp_image_token_length):
-        super().__init__(dataset, tokenizer, image_processor, mp_image_token_length)
-
     def __getitem__(self, idx):
         item = self.dataset[idx]
 
@@ -63,28 +84,9 @@ class VQADataset(BaseDataset):  # Visual Question Answering Dataset
             images_data = [images_data]
 
         # Now process the images
-        processed_images = []
-        for image in images_data:
-            if isinstance(image, Image.Image):
-                if image.mode != 'RGB':
-                    image = image.convert('RGB')
-                processed_image = self.image_processor(image)
-                processed_images.append(processed_image)
-            else:
-                raise ValueError(f"Error processing image at index {idx}")
+        processed_images = self._process_images(images_data)
 
-        # Process text (should be a list)
-        text_data = item['texts']
-        if not isinstance(text_data, list):
-            text_data = [text_data]
-
-        messages = []
-
-        for text in text_data:
-            messages.append({"role": "user", "content": text['user']})
-            messages.append({"role": "assistant", "content": text['assistant']})
-
-        messages[0]["content"] = self.tokenizer.image_token * len(processed_images) * self.mp_image_token_length + messages[0]["content"]      
+        messages = self._get_messages(item, len(processed_images))
 
         input_ids, mask, attention_mask = self._prepare_inputs_and_loss_mask(messages)
         labels = self._get_labels(input_ids, mask)
@@ -108,29 +110,21 @@ class MMStarDataset(BaseDataset):  # https://huggingface.co/datasets/Lin-Chen/MM
         item = self.dataset[idx]
         
         image = item['image']
-            
-        # Now process the image
-        if isinstance(image, Image.Image):
-            if image.mode != 'RGB':
-                image = image.convert('RGB')
-            processed_image = self.image_processor(image)
-        else:
-            raise ValueError(f"Error processing image at index {idx}")
+        processed_images = self._process_images([image])
         
-        messages = []
+        item['texts'] = [{
+            "user": item['question'] +  "\nAnswer only with the letter!",
+            "assistant": item['answer']
+        }]
+        messages = self._get_messages(item, image_count=len(processed_images))
 
-        messages.append({"role": "user", "content": item['question'] +  "\nAnswer only with the letter!"})
-        messages.append({"role": "assistant", "content": item['answer']})
-
-        messages[0]["content"] = self.tokenizer.image_token * self.mp_image_token_length + messages[0]["content"]      
-        
         input_ids, mask, attention_mask = self._prepare_inputs_and_loss_mask(messages)
         labels = self._get_labels(input_ids, mask)
         input_ids = input_ids.masked_fill(mask, self.tokenizer.pad_token_id)
         attention_mask = attention_mask.masked_fill(mask, 0)
 
         return {
-            "images": [processed_image],
+            "images": processed_images,
             "input_ids": input_ids,
             "attention_mask": attention_mask,
             "labels": labels,
@@ -139,3 +133,104 @@ class MMStarDataset(BaseDataset):  # https://huggingface.co/datasets/Lin-Chen/MM
     def _get_labels(self, input_ids, mask):
         labels = input_ids.clone().masked_fill(~mask, self.tokenizer.pad_token_id)
         return labels
+
+
+class ConstantLengthDataset(IterableDataset):
+    def __init__(
+        self, dataset, infinite=False, seq_length=1024, num_of_sequences=1024
+    ):
+        self.dataset = dataset
+        self.seq_length = seq_length
+        self.max_length = seq_length * num_of_sequences
+        self.epoch = 0
+        self.infinite = infinite
+
+    def __len__(self):
+        return int(len(self.dataset) * 256/self.seq_length)
+
+    def _balanced_greedy_knapsack(self, lengths, L, delta=0):
+        # keep the position while sorting
+        items = sorted(enumerate(lengths), key=lambda x: x[1], reverse=True)
+
+        min_knapsacks   = (sum(lengths) + L - 1) // L + delta
+        knapsack_load   = [0]   * min_knapsacks
+        knapsack_groups = [[] for _ in range(min_knapsacks)]
+
+        for idx, item_len in items:
+            # choose the lightest knapsack so far
+            ks_id = min(range(len(knapsack_load)),
+                        key=knapsack_load.__getitem__)
+
+            # open a new one if the chosen bag would overflow
+            if knapsack_load[ks_id] + item_len > L:
+                ks_id = len(knapsack_load)
+                knapsack_load   .append(0)
+                knapsack_groups.append([])
+
+            knapsack_groups[ks_id].append(idx)
+            knapsack_load  [ks_id] += item_len
+
+        # remove the completely empty bags that the +delta heuristic created
+        return [g for g in knapsack_groups if g]
+
+    def _pack_one_group(self, group_indices, batch,
+                        max_len):
+        ids, lbl, am, ims = [], [], [], []
+
+        for i in group_indices:
+            ids.extend(batch[i]["input_ids"])
+            lbl.extend(batch[i]["labels"])
+            am .extend(batch[i]["attention_mask"])
+            ims.extend(batch[i]["images"])
+
+        # safety: assert we never overflow
+        if len(ids) > max_len:
+            raise ValueError(f"Packed length {len(ids)} > max_len {max_len}")
+
+        return torch.stack(ids), torch.stack(lbl), torch.stack(am), ims
+
+    def __iter__(self):
+        iterator = iter(self.dataset)
+        more_examples = True
+        while more_examples:
+            buffer, buffer_len = [], 0
+            while True:
+                if buffer_len >= self.max_length:
+                    break
+                try:
+                    next_sample = next(iterator)
+                    if len(next_sample["input_ids"]) > self.seq_length:
+                        continue  # Discard samples that are too long
+                    buffer.append(next_sample)
+                    buffer_len += len(next_sample["input_ids"])
+                except StopIteration:
+                    if self.infinite:
+                        iterator = iter(self.dataset)
+                        self.epoch += 1
+                    else:
+                        more_examples = False
+                        break
+
+            # 1) run knapsack on the lengths
+            lengths = list(map(lambda x: len(x["input_ids"]), buffer))
+            groups  = self._balanced_greedy_knapsack(lengths, self.seq_length, delta=5)
+
+            # 2) build new (packed) lists
+            packed_ids, packed_lbl, packed_am, packed_imgs = [], [], [], []
+
+            for g in groups:
+                ids, lbl, am, ims = self._pack_one_group(
+                    g, buffer, self.seq_length
+                )
+                packed_ids .append(ids)
+                packed_lbl .append(lbl)
+                packed_am  .append(am)
+                packed_imgs.append(ims)
+
+            for i in range(len(packed_ids)):
+                yield {
+                    "input_ids": packed_ids[i],
+                    "labels": packed_lbl[i],
+                    "attention_mask": packed_am[i],
+                    "images": packed_imgs[i]
+                }

--- a/data/datasets.py
+++ b/data/datasets.py
@@ -5,15 +5,54 @@ from torch.utils.data import Dataset
 import models.config as cfg
 
 
-class VQADataset(Dataset):  # Visual Question Answering Dataset
+class BaseDataset(Dataset):
     def __init__(self, dataset, tokenizer, image_processor, mp_image_token_length):
         self.dataset = dataset
         self.tokenizer = tokenizer
         self.image_processor = image_processor
         self.mp_image_token_length = mp_image_token_length
 
+        self.prefix_len = self._get_prefix_len()
+
     def __len__(self):
         return len(self.dataset)
+
+    def _get_prefix_len(self):
+        random_string_5_letters = "xzyvd"
+        random_string_chat_templated = self.tokenizer.apply_chat_template([{"role": "assistant", "content": random_string_5_letters}], tokenize=False, add_special_tokens=False)
+        random_string_location = random_string_chat_templated.find(random_string_5_letters)
+        return len(self.tokenizer.encode(random_string_chat_templated[:random_string_location]))
+
+    def _prepare_inputs_and_loss_mask(self, messages):
+        conv_ids = self.tokenizer.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_special_tokens=False,
+            return_dict=True,
+        )
+        mask = [0] * len(conv_ids["input_ids"])
+
+        # Locate each assistant turn and flip its mask to 1
+        cursor = 0
+        for msg in messages:
+            segment_ids = self.tokenizer.apply_chat_template(
+                [msg], tokenize=True, add_special_tokens=False
+            )
+            seg_len = len(segment_ids)
+
+            if msg["role"] == "assistant":
+                start = cursor + self.prefix_len
+                end   = cursor + seg_len
+                mask[start:end] = [1] * (end - start)  # attend to these tokens
+
+            cursor += seg_len
+        
+        return torch.tensor(conv_ids["input_ids"]), torch.tensor(mask).to(torch.bool), torch.tensor(conv_ids["attention_mask"])
+
+
+class VQADataset(BaseDataset):  # Visual Question Answering Dataset
+    def __init__(self, dataset, tokenizer, image_processor, mp_image_token_length):
+        super().__init__(dataset, tokenizer, image_processor, mp_image_token_length)
 
     def __getitem__(self, idx):
         item = self.dataset[idx]
@@ -47,22 +86,24 @@ class VQADataset(Dataset):  # Visual Question Answering Dataset
 
         messages[0]["content"] = self.tokenizer.image_token * len(processed_images) * self.mp_image_token_length + messages[0]["content"]      
 
+        input_ids, mask, attention_mask = self._prepare_inputs_and_loss_mask(messages)
+        labels = self._get_labels(input_ids, mask)
+
         return {
             "images": processed_images,
-            "text_data": messages,
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "labels": labels,
         }
 
+    def _get_labels(self, input_ids, mask):
+        labels = input_ids.clone().masked_fill(~mask, -100)
+        labels = labels.roll(-1) # Shift labels for causal LM
+        labels[-1] = -100 # Last token has no target
+        
+        return labels
 
-class MMStarDataset(Dataset):  # https://huggingface.co/datasets/Lin-Chen/MMStar
-    def __init__(self, dataset, tokenizer, image_processor, mp_image_token_length):
-        self.dataset = dataset
-        self.tokenizer = tokenizer
-        self.image_processor = image_processor
-        self.mp_image_token_length = mp_image_token_length
-
-    def __len__(self):
-        return len(self.dataset)
-    
+class MMStarDataset(BaseDataset):  # https://huggingface.co/datasets/Lin-Chen/MMStar
     def __getitem__(self, idx):
         item = self.dataset[idx]
         
@@ -83,7 +124,18 @@ class MMStarDataset(Dataset):  # https://huggingface.co/datasets/Lin-Chen/MMStar
 
         messages[0]["content"] = self.tokenizer.image_token * self.mp_image_token_length + messages[0]["content"]      
         
+        input_ids, mask, attention_mask = self._prepare_inputs_and_loss_mask(messages)
+        labels = self._get_labels(input_ids, mask)
+        input_ids = input_ids.masked_fill(mask, self.tokenizer.pad_token_id)
+        attention_mask = attention_mask.masked_fill(mask, 0)
+
         return {
-            "image": processed_image,
-            "text_data": messages,
+            "images": [processed_image],
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "labels": labels,
         }
+
+    def _get_labels(self, input_ids, mask):
+        labels = input_ids.clone().masked_fill(~mask, self.tokenizer.pad_token_id)
+        return labels

--- a/data/datasets.py
+++ b/data/datasets.py
@@ -1,10 +1,7 @@
 import torch
 from PIL import Image
-from torch.utils.data import Dataset, IterableDataset, get_worker_info
-import threading
-from queue import Queue
-from typing import Iterator
-import itertools
+from torch.utils.data import Dataset
+
 
 class BaseDataset(Dataset):
     def __init__(self, dataset, tokenizer, image_processor, mp_image_token_length):
@@ -44,7 +41,7 @@ class BaseDataset(Dataset):
                 processed_image = self.image_processor(image)
                 processed_images.append(processed_image)
             else:
-                raise ValueError(f"Error processing image")
+                raise ValueError("Error processing image")
         return processed_images
 
 
@@ -135,152 +132,3 @@ class MMStarDataset(BaseDataset):  # https://huggingface.co/datasets/Lin-Chen/MM
         labels = input_ids.clone().masked_fill(~mask, self.tokenizer.pad_token_id)
         return labels
 
-
-class ConstantLengthDataset(IterableDataset):
-    def __init__(
-        self,
-        dataset, infinite: bool = False, seq_length: int = 1024, num_of_sequences: int = 1024, queue_size: int = 2048,
-    ):
-        self.dataset = dataset
-        self.seq_length = seq_length
-        self.max_length = seq_length * num_of_sequences
-        self.epoch = 0  # only advanced when infinite=True
-        self.infinite = infinite
-        self.queue_size = queue_size
-        self._sentinel = object()
-
-    def __len__(self):
-        return int(len(self.dataset) * 256/self.seq_length)
-
-    def __iter__(self) -> Iterator[dict]:
-        """
-        Returns a consumer iterator that drains `self._queue`.
-        A background thread keeps that queue topped up.
-        """
-        worker_info = get_worker_info()
-        worker_id = worker_info.id if worker_info else 0
-        num_workers = worker_info.num_workers if worker_info else 1
-
-        def make_base_iterator():
-            """Return a (sharded) iterator over the underlying dataset."""
-            all_indices = range(len(self.dataset))
-
-            # Shard the *indices* first, before any data is fetched.
-            if num_workers > 1:
-                worker_indices = itertools.islice(all_indices, worker_id, None, num_workers)
-            else:
-                worker_indices = all_indices
-
-            # Create an iterator that only calls __getitem__ for the assigned indices.
-            def sharded_item_iterator():
-                for idx in worker_indices:
-                    yield self.dataset[idx]
-
-            return sharded_item_iterator()        
-        
-        queue: Queue = Queue(maxsize=self.queue_size)
-
-        producer = threading.Thread(
-            target=self._producer, args=(make_base_iterator, queue), daemon=True
-        )
-        producer.start()
-
-        while True:
-            sample = queue.get()
-            if sample is self._sentinel:
-                break
-            yield sample
-
-    def _producer(
-            self,
-            make_iterator,  # a zero-arg lambda that returns a fresh (possibly sharded) iterator
-            queue: Queue,
-        ):
-        """Runs in a separate daemon thread and keeps `queue` full."""
-        iterator = make_iterator()
-        more_examples = True
-
-        while more_examples:
-            # ------------- 1) pull raw samples until we have enough -------- #
-            buffer, buffer_len = [], 0
-            while buffer_len < self.max_length:
-                try:
-                    sample = next(iterator)
-                except StopIteration:
-                    if self.infinite:
-                        iterator = make_iterator()
-                        self.epoch += 1
-                        continue
-                    else:
-                        more_examples = False
-                        break
-
-                if len(sample["input_ids"]) > self.seq_length:
-                    continue  # skip overly long samples
-
-                buffer.append(sample)
-                buffer_len += len(sample["input_ids"])
-
-            if not buffer:
-                break  # nothing left and not infinite
-
-            # ------------- 2) run greedy knapsack & pack groups ------------ #
-            lengths = [len(x["input_ids"]) for x in buffer]
-            groups = self._balanced_greedy_knapsack(lengths, self.seq_length, delta=5)
-
-            for g in groups:
-                packed = self._pack_one_group(g, buffer, self.seq_length)
-
-                # put blocks if queue is full.
-                queue.put(
-                    {
-                        "input_ids": packed[0],
-                        "labels": packed[1],
-                        "attention_mask": packed[2],
-                        "images": packed[3],
-                    }
-                )
-
-        # finished → unblock consumer
-        queue.put(self._sentinel)
-
-    def _balanced_greedy_knapsack(self, lengths, L, delta=0):
-        # keep the position while sorting
-        items = sorted(enumerate(lengths), key=lambda x: x[1], reverse=True)
-
-        min_knapsacks   = (sum(lengths) + L - 1) // L + delta
-        knapsack_load   = [0]   * min_knapsacks
-        knapsack_groups = [[] for _ in range(min_knapsacks)]
-
-        for idx, item_len in items:
-            # choose the lightest knapsack so far
-            ks_id = min(range(len(knapsack_load)),
-                        key=knapsack_load.__getitem__)
-
-            # open a new one if the chosen bag would overflow
-            if knapsack_load[ks_id] + item_len > L:
-                ks_id = len(knapsack_load)
-                knapsack_load   .append(0)
-                knapsack_groups.append([])
-
-            knapsack_groups[ks_id].append(idx)
-            knapsack_load  [ks_id] += item_len
-
-        # remove the completely empty bags that the +delta heuristic created
-        return [g for g in knapsack_groups if g]
-
-    def _pack_one_group(self, group_indices, batch,
-                        max_len):
-        ids, lbl, am, ims = [], [], [], []
-
-        for i in group_indices:
-            ids.extend(batch[i]["input_ids"])
-            lbl.extend(batch[i]["labels"])
-            am .extend(batch[i]["attention_mask"])
-            ims.extend(batch[i]["images"])
-
-        # safety: assert we never overflow
-        if len(ids) > max_len:
-            raise ValueError(f"Packed length {len(ids)} > max_len {max_len}")
-
-        return torch.stack(ids), torch.stack(lbl), torch.stack(am), ims

--- a/data/datasets.py
+++ b/data/datasets.py
@@ -4,13 +4,11 @@ from torch.utils.data import Dataset, IterableDataset
 
 
 class BaseDataset(Dataset):
-    def __init__(self, dataset, tokenizer, image_processor, mp_image_token_length, rank=0, num_replicas=1):
+    def __init__(self, dataset, tokenizer, image_processor, mp_image_token_length):
         self.dataset = dataset
         self.tokenizer = tokenizer
         self.image_processor = image_processor
         self.mp_image_token_length = mp_image_token_length
-        self.rank = rank
-        self.num_replicas = num_replicas
 
         self.prefix_len = self._get_prefix_len()
 

--- a/models/config.py
+++ b/models/config.py
@@ -27,7 +27,7 @@ class VLMConfig:
     lm_dropout: float = 0.0
     lm_n_blocks: int = 30
     lm_attn_scaling: float = 1.0
-    lm_max_length: int = 512
+    lm_max_length: int = 1024
     lm_use_tokens: bool = False # Decide if the LM expects tokens or embeddings as input (if using as a backbone for the VLM, set to False)
     lm_tie_weights: bool = True # Decide if you want to tie the LM Head weight to the token embedding weights
     lm_model_type: str = 'HuggingFaceTB/SmolLM2-360M-Instruct'
@@ -50,7 +50,7 @@ class TrainConfig:
     lr_backbones: float = 5e-5
     data_cutoff_idx: int = None
     val_ratio: float = 0.025
-    batch_size: int = 32
+    batch_size: int = 16
     gradient_accumulation_steps: int = 4
     mmstar_batch_size: int = 32
     max_grad_norm: float = 1.0

--- a/models/config.py
+++ b/models/config.py
@@ -56,7 +56,8 @@ class TrainConfig:
     max_grad_norm: float = 1.0
     eval_in_epochs: bool = True
     eval_interval: int = 250
-    epochs: int = 10
+    stats_log_interval: int = 100
+    max_training_steps: int = 8000
     max_images_per_example: int = 4
     max_images_per_knapsack: int = 18
     max_sample_length: int = 1024

--- a/models/config.py
+++ b/models/config.py
@@ -56,7 +56,10 @@ class TrainConfig:
     max_grad_norm: float = 1.0
     eval_in_epochs: bool = True
     eval_interval: int = 250
-    epochs: int = 5
+    epochs: int = 10
+    max_images_per_example: int = 4
+    max_images_per_knapsack: int = 18
+    max_sample_length: int = 1024
     compile: bool = False
     resume_from_vlm_checkpoint: bool = False # Indicate if the training should be resumed from a checkpoint of the whole VLM or you want to start from scratch
     train_dataset_path: str = 'HuggingFaceM4/the_cauldron'

--- a/train.py
+++ b/train.py
@@ -106,7 +106,7 @@ def get_dataloaders(train_cfg, vlm_cfg):
 
     train_dataset = VQADataset(train_ds.select(range(train_size)), tokenizer, image_processor, vlm_cfg.mp_image_token_length)
     
-    train_dataset = ConstantLengthDataset(train_dataset, infinite=False, max_sample_length=train_cfg.max_sample_length, seq_length=vlm_cfg.lm_max_length, num_of_sequences=train_cfg.batch_size*64, queue_size=train_cfg.batch_size*64*2,
+    train_dataset = ConstantLengthDataset(train_dataset, infinite=False, max_sample_length=train_cfg.max_sample_length, seq_length=vlm_cfg.lm_max_length, num_of_sequences=train_cfg.batch_size*128, queue_size=train_cfg.batch_size*128*2,
                                           max_images_per_example=train_cfg.max_images_per_example, max_images_per_knapsack=train_cfg.max_images_per_knapsack)
     val_dataset = VQADataset(train_ds.select(range(train_size, total_samples)), tokenizer, image_processor, vlm_cfg.mp_image_token_length)
     # val_dataset = ConstantLengthDataset(val_dataset, infinite=False, max_sample_length=train_cfg.max_sample_length, seq_length=vlm_cfg.lm_max_length, num_of_sequences=train_cfg.batch_size*4, queue_size=train_cfg.batch_size*4*2,


### PR DESCRIPTION
Big boy refactor to make the balanced packing strategy from Nvidia's Eagle 2 paper in nanovlm. 

The good:
- Token throughput increased from 70k to 330k. 5-fold!
- Epoch duration reduced from 2900 seconds to 1300 seconds. 2.2 times! (I'm not sure where the difference with token throughput comes from, we now test on mmstar twice during one epoch, since epochs now have less steps, we used to do it more)
- GPU utilization is constantly high
- Validation loss looks great. Accuracy on MMStar is ok, it seems more stable than before, so the peaks aren't as high.

The PR has lots of commits since I went a bit back and forth on how to do it. The final result is:

Normal Datasets -> They now load images and text, prepare the prompts, apply chat templates, and tokenize the inputs. They also preprocess images (only resizing by now). They return a dict of labels, input_ids, attention_masks, processed_images.

Constant Length Dataset -> Takes one of the normal datasets and packs it. For this, it dynamically gets a large number of samples (approx 10 batches from before), and then used them to create groups of packed samples. Packed samples are simply one sample after another one from the normal datasets until reaching the max sequence length. The "balanced" part is that every group should have a similar distribution of lengths from samples. I took the main code for that from the Nvidia Eagle 2 paper. 
Because this processing takes ±3 mins, I create a queue and fill it in a different thread from the dataloader worker. That queue will fill up to 4 full batches such that the dataset always has samples to return. In practice, this is then mostly done while the GPU is busy with fwd/bwd, so we never wait for samples and GPU utilization is maxxed out.
Also, this constant length dataset manually shards itself when it detects several workers on the dataloader. This is needed since we can't use a default sampling strategy from PyTorch. The implementation directly divides the indices to avoid having each instance of the constant length dataset iterate over all datasets redoing the preprocessing.

Collators -> They are quite dumb, basically take samples from a dataset and discard samples that are too long and pad. If using with a constant-length dataset, there won't be samples that are too long, but I kept that so that it also works with the normal dataset. 

Training loop -> When creating the data, if we are on DDP, we manually shard the datasets. This is needed since we can't have a distributed sampler with an iterable dataset (like the constant length dataset). Then, because the datasets create packs and discards samples that are too long, not all ranks finish at the same time. So I added a wrapper on the dataloader to check if all the machines still have data, whenever one finished it's data, they all finish. This might drop a little bit of data, but nothing major. 
I also added timing logging to data loading, fwd/bwd, and post-processing. Useful to check speed-up improvements. 