### PR TITLE
Fix tokenization bug in lmms_eval_wrapper.py

### DIFF
--- a/eval/lmms_eval_wrapper.py
+++ b/eval/lmms_eval_wrapper.py
@@ -136,6 +136,7 @@ class NanoVLMWrapper(lmms):
                 prompts,
                 return_tensors="pt",
                 padding="longest",
+                padding_side="left",
                 truncation=True,
                 max_length=self.max_length
             )


### PR DESCRIPTION
Great to see the additional eval options in the repo! I tried running it and found a tokenization bug in `lmms_eval_wrapper.py`. The inputs to the model are padded on the right instead of the left and this results in degraded outputs. 

This PR should fix that. I tested the changes with lusxvr/nanoVLM-450M on mmstar and mme, and the benchmark results improved for both: mmstar improved from .3020 to .3384, mme cognition score went from 217.1429 to 257.1429 and mme perception score went from 719.5 to 774.494.