### PR TITLE
Removed manual MMStar Evaluation

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -110,7 +110,7 @@ def parse_eval_args() -> argparse.Namespace:
         "--batch_size",
         "-b",
         type=str,
-        default=32,
+        default=128,
         metavar="auto|auto:N|N",
         help="Acceptable values are 'auto', 'auto:N' or N, where N is an integer. Default 1.",
     )
@@ -281,7 +281,7 @@ def evaluate(
     tasks: str = None,
     model_args: str = "",
     num_fewshot: int = None,
-    batch_size: str = "32",
+    batch_size: str = "128",
     max_batch_size: int = None,
     device: str = "cuda",
     output_path: str = "results/",

--- a/models/config.py
+++ b/models/config.py
@@ -55,9 +55,9 @@ class TrainConfig:
     mmstar_batch_size: int = 32
     max_grad_norm: float = 1.0
     eval_in_epochs: bool = True
-    eval_interval: int = 200 # Needs to be a multiple of the gradient_accumulation_steps
-    stats_log_interval: int = 100 # Needs to be a multiple of the gradient_accumulation_steps
-    max_training_steps: int = 8000
+    eval_interval: int = gradient_accumulation_steps * 100
+    stats_log_interval: int = gradient_accumulation_steps * 25
+    max_training_steps: int = 5000
     max_images_per_example: int = 4
     max_images_per_knapsack: int = 18
     max_sample_length: int = 1024

--- a/models/config.py
+++ b/models/config.py
@@ -71,4 +71,4 @@ class TrainConfig:
     use_lmms_eval: bool = True # Use lmms-eval for evaluation
     lmms_eval_tasks: str = 'mmstar,mmmu,ocrbench,textvqa' # Pass additional task as one string, seperated by commas without spaces (e.g. 'mmstar,mmmu,ocrbench')
     lmms_eval_limit: int = None
-    lmms_eval_batch_size: int = 32
+    lmms_eval_batch_size: int = 128

--- a/models/config.py
+++ b/models/config.py
@@ -55,8 +55,8 @@ class TrainConfig:
     mmstar_batch_size: int = 32
     max_grad_norm: float = 1.0
     eval_in_epochs: bool = True
-    eval_interval: int = 250
-    stats_log_interval: int = 100
+    eval_interval: int = 200 # Needs to be a multiple of the gradient_accumulation_steps
+    stats_log_interval: int = 100 # Needs to be a multiple of the gradient_accumulation_steps
     max_training_steps: int = 8000
     max_images_per_example: int = 4
     max_images_per_knapsack: int = 18

--- a/train.py
+++ b/train.py
@@ -290,8 +290,8 @@ def train(train_cfg, vlm_cfg):
                 if train_cfg.max_grad_norm is not None:
                     grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_norm=train_cfg.max_grad_norm)
 
-                adj_lr_mp = get_lr(global_step, train_cfg.lr_mp, train_cfg.max_training_steps // train_cfg.gradient_accumulation_steps)
-                adj_lr_backbones = get_lr(global_step, train_cfg.lr_backbones, train_cfg.max_training_steps // train_cfg.gradient_accumulation_steps)
+                adj_lr_mp = get_lr(global_step, train_cfg.lr_mp, train_cfg.max_training_steps)
+                adj_lr_backbones = get_lr(global_step, train_cfg.lr_backbones, train_cfg.max_training_steps)
                 optimizer.param_groups[0]['lr'] = adj_lr_mp
                 optimizer.param_groups[1]['lr'] = adj_lr_backbones
                 optimizer.step()

--- a/train.py
+++ b/train.py
@@ -358,7 +358,7 @@ def train(train_cfg, vlm_cfg):
                             for task_name, task_results in eval_results[0]["results"].items():
                                 for metric_name, metric_value in task_results.items():
                                     if isinstance(metric_value, (int, float)):
-                                        lmms_results[f"lmms_{task_name}_{metric_name.split(',')[0]}"] = metric_value
+                                        lmms_results[f"{task_name}_{metric_name.split(',')[0]}"] = metric_value
                     
                     if is_master():
                         print(f"Step: {global_step}, Val Loss: {avg_val_loss:.4f}, Tokens/s: {tokens_per_second:.2f}")

--- a/train.py
+++ b/train.py
@@ -344,7 +344,7 @@ def train(train_cfg, vlm_cfg):
                             save_model.save_pretrained(save_directory=os.path.join(vlm_cfg.vlm_checkpoint_path, run_name))
 
                     lmms_results = {}
-                    if train_cfg.use_lmms_eval and global_step % (train_cfg.eval_interval*2) == 0:
+                    if train_cfg.use_lmms_eval:
                         eval_results = evaluate(
                             model=model.module if is_dist() else model,
                             tasks=train_cfg.lmms_eval_tasks,


### PR DESCRIPTION
After integrating lmms-eval, I removed the old manual mmstar implementation. Additionally, moved the wandb logging of the evaluation to its own section.

Also fixed a slight bug in the learning rate scheduler in how the `max_steps` are passed.