### PR TITLE
Make lmms_eval, accelerate dependency conditional on use_lmms_eval

### DIFF
--- a/train.py
+++ b/train.py
@@ -25,7 +25,6 @@ from data.processors import get_image_processor, get_tokenizer
 from models.vision_language_model import VisionLanguageModel
 import models.config as config
 import models.utils as utils
-from evaluation import cli_evaluate
 from data.data_utils import synchronized_dataloader_step
 
 #Otherwise, the tokenizer will throw a warning
@@ -345,6 +344,8 @@ def train(train_cfg, vlm_cfg):
 
                     lmms_results = {}
                     if train_cfg.use_lmms_eval:
+                        from evaluation import cli_evaluate
+                        
                         eval_args = argparse.Namespace(
                             model=model.module if is_dist() else model,
                             tasks=train_cfg.lmms_eval_tasks,


### PR DESCRIPTION
Move `cli_evaluate` import inside conditional block to prevent importing lmms-eval and accelerate when `use_lmms_eval` is False. This allows users who explicitly disable lmms-eval in their config to avoid the lmms-eval and accelerate dependency (see #121).