### PR TITLE
Remove unused lm_eos_token_id from Config

### DIFF
--- a/models/config.py
+++ b/models/config.py
@@ -33,7 +33,6 @@ class VLMConfig:
     lm_model_type: str = 'HuggingFaceTB/SmolLM2-360M-Instruct'
     lm_tokenizer: str = 'HuggingFaceTB/SmolLM2-360M-Instruct'
     lm_chat_template: str = "{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}"
-    lm_eos_token_id: int = 0
 
     mp_pixel_shuffle_factor: int = 2
     mp_image_token_length: int = 64


### PR DESCRIPTION
While reading and understanding the code, I noticed that the VLMConfig dataclass in config.py defines a field:
`lm_eos_token_id: int = 0`

This parameter is dead code:
It is never referenced or used anywhere else in the codebase.
All EOS token handling throughout the model is done dynamically via `self.tokenizer.eos_token_id`.

Keeping this unused and incorrect parameter can mislead developers into thinking it affects model behavior, when in reality it does not.

Refer issue #137 

### Before(**models/config.py**)
```
lm_chat_template: str = "{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] +'<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}"
lm_eos_token_id: int = 0
mp_pixel_shuffle_factor: int = 2
```

### After(**models/config.py**)

```
lm_chat_template: str = "{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] +'<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}"
mp_pixel_shuffle_factor: int = 2
```

Existing Functionality Is Unchanged:
The codebase already uses self.tokenizer.eos_token_id everywhere EOS token logic is required.
There are no references to lm_eos_token_id in any model, function, or utility.
Removing this line does not affect any runtime behavior, configuration, or output.

**This PR simply removes dead code, improves clarity, and prevents future confusion.**
