### PR TITLE
pass no_log_wandb to the evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ checkpoints/
 notebooks/
 results/
 *.slurm
+*.arrow
+/shards/*
+*.png


### PR DESCRIPTION
Without this, `python train.py --no_log_wandb` breaks when it gets to the evaluation.