### PR TITLE
fix: change batch key from "image" to "images" in measure_vram.py

### DIFF
--- a/eval/measure_vram.py
+++ b/eval/measure_vram.py
@@ -127,7 +127,7 @@ def measure_vram(args, vlm_cfg, train_cfg_defaults):
                 if i >= num_iterations_for_vram:
                     break
                 
-                images = batch["image"].to(device)
+                images = batch["images"]
                 input_ids = batch["input_ids"].to(device)
                 labels = batch["labels"].to(device)
                 attention_mask = batch["attention_mask"].to(device)


### PR DESCRIPTION
## Description

Fixes a KeyError in `eval/measure_vram.py` where the code tries to access batch["image"], 
but the correct key is batch["images"]. 

Specifically, when running `eval/measure_vram.py`, I encountered the following error:

KeyError: 'image'
  File ".../measure_vram.py", line 130, in measure_vram
    images = batch["image"].to(device)

After checking `train.py`, I noticed that similar code has already been updated to use:

    batch["images"]

This suggests that `measure_vram.py` may not have been updated accordingly.

## Related Issue

No issue submitted for this simple fix.

## Testing

- Ran `python eval/measure_vram.py` and confirmed this error is resolved.
- Further testing revealed other unrelated issues, which will be reported separately.

## Notes

This is a straightforward fix to unblock running the evaluation script.
