### PR TITLE
fix: typo

### DIFF
--- a/train_nanoVLM.ipynb
+++ b/train_nanoVLM.ipynb
@@ -131,7 +131,7 @@
         "from torch.utils.data import DataLoader\n",
         "from datasets import load_dataset, concatenate_datasets, get_dataset_config_names\n",
         "\n",
-        "#Otherwise, the tokenizer will through a warning\n",
+        "#Otherwise, the tokenizer will throw a warning\n",
         "import os\n",
         "os.environ[\"TOKENIZERS_PARALLELISM\"] = \"false\"\n",
         "\n",


### PR DESCRIPTION
Fixed a typo in the 5th cell in the train_nanoVLM notebook
Changed "through" to "throw" for better readability
Edit: location of the typo in code
Edit2: more detailed description