### PR TITLE
docs: fix typos and tighten lmms-eval wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@
 ---
 
 > [!NOTE]
-> We have pushed some more breaking changes on September 9, 2025. These are all the updates to use image splitting and train on multiple nodes. This was used for the ablations of the FineVision release. Some things in the codebase regarding support scripts (eg. the notebook, or memory evals) are propably not working anymore. Similarly to the older trained versions of nanoVLM (similarly to Note below). If you find something that doesn't work anymore please let us know in the Issues or submit a PR!
+> We have pushed some more breaking changes on September 9, 2025. These are all the updates to use image splitting and train on multiple nodes. This was used for the ablations of the FineVision release. Some things in the codebase regarding support scripts (eg. the notebook, or memory evals) are probably not working anymore. Similarly to the older trained versions of nanoVLM (similarly to Note below). If you find something that doesn't work anymore please let us know in the Issues or submit a PR!
 
 ---
 
 > [!NOTE]
-> We have pushed some breaking changes to the repository on June 4, 2025. To enable us to do smarter packing, we refactored the way image and text embeddings are combined. To keep everything as smooth as possible, we have trained a new nanoVLM-450M with this new pipeline, while leaving the old nanoVLM-222M compatible with the old pipeline If you clone this repository now or pull the updated to your local machine, the default will be the new 450M Model. If you would like a simpler understanding and a simpler codebase, you can use the v0.1 release. This works out of the box with the old 222M model.
+> We have pushed some breaking changes to the repository on June 4, 2025. To enable us to do smarter packing, we refactored the way image and text embeddings are combined. To keep everything as smooth as possible, we have trained a new nanoVLM-450M with this new pipeline, while leaving the old nanoVLM-222M compatible with the old pipeline If you clone this repository now or pull the updates to your local machine, the default will be the new 450M Model. If you would like a simpler understanding and a simpler codebase, you can use the v0.1 release. This works out of the box with the old 222M model.
 
 ---
 
@@ -27,10 +27,9 @@ nanoVLM is the simplest repository for training/finetuning a small sized Vision-
 
 Similar to Andrej Karpathy's nanoGPT, we wanted to equip the community with a very simple implementation and training script for Vision Language Models. We do not claim this to be a new SOTA model, rather an educational effort that packs quite a bit of punch if you have the right hardware! You should be able to tweak and play around with the code in no time.
 
-
 ## What can nanoVLM do?
 
-The model definition and training logic of this repository fits in ~750 lines, with some more boilerplate logging and parameter loading. 
+The model definition and training logic of this repository fits in ~750 lines, with some more boilerplate logging and parameter loading.
 Using the [`SigLIP-B/16-224-85M`](https://huggingface.co/google/siglip-base-patch16-224) and [`HuggingFaceTB/SmolLM2-135M`](https://huggingface.co/HuggingFaceTB/SmolLM2-135M) as backbones results in a **222M** nanoVLM. Training this for ~6h on a single H100 GPU on ~1.7M samples of [the cauldron](https://huggingface.co/datasets/HuggingFaceM4/the_cauldron) results in an accuracy of 35.3% on MMStar.
 
 ![loss](assets/nanoVLM-222M-loss.png)
@@ -41,18 +40,19 @@ It is therefore a simple yet powerful platform to get started with VLMs. Perfect
 
 You can either clone the repository, setup an environment and start with the scripts, or directly [open in Colab](https://colab.research.google.com/github/huggingface/nanoVLM/blob/main/nanoVLM.ipynb). You can also use the [interactive notebook](./nanoVLM.ipynb) to get started!
 
-
 ## Environment Setup
 
 We really like `uv` and recommend using it as your package manager. But feel free to use whichever you prefer.
 
 Let's first clone the repository:
+
 ```bash
 git clone https://github.com/huggingface/nanoVLM.git
 cd nanoVLM
 ```
 
 If you want to use `uv`:
+
 ```bash
 uv init --bare --python 3.12
 uv sync --python 3.12
@@ -61,13 +61,16 @@ uv add torch numpy torchvision pillow datasets huggingface-hub transformers wand
 # Optional: for lmms-eval integration you have to install it from source, see section 'Evaluation with lmms-eval'
 ```
 
-If you prefer another environment manager, simply install these packages:  
+If you prefer another environment manager, simply install these packages:
+
 ```bash
 pip install torch numpy torchvision pillow datasets huggingface-hub transformers wandb
 # Optional: for lmms-eval integration you have to install it from source, see section 'Evaluation with lmms-eval'
 
 ```
-Dependencies: 
+
+Dependencies:
+
 - `torch` <3
 - `numpy` <3
 - `torchvision` for the image processors
@@ -79,27 +82,33 @@ Dependencies:
 ## Training
 
 To train nanoVLM, you can simply use the provided training script. After training, your model gets uploaded to the Hub!
+
 ```bash
 wandb login --relogin
 huggingface-cli login
 python train.py
 ```
+
 which will use the default `models/config.py`.
 
 ## Generate
 
 To try a [trained model](https://huggingface.co/lusxvr/nanoVLM-450M), you can simply use the provided generate script
+
 ```bash
 python generate.py
 ```
+
 or, to use your own trained model, you can simply run:
+
 ```bash
 python generate.py --checkpoint /your/path/to/trained_models
 ```
 
-If we feed the example image in `assets/image.png` with a question into the model, we get the following output. Even after only short training, the model can recognize the cat in the picture. 
+If we feed the example image in `assets/image.png` with a question into the model, we get the following output. Even after only short training, the model can recognize the cat in the picture.
+
 ```
-Input: 
+Input:
 Image + 'What is this?'
 
 Outputs:
@@ -126,7 +135,6 @@ huggingface-cli login
 python evaluation.py --model lusxvr/nanoVLM-450M --tasks mmstar,mme
 
 # If you want to use it during training, simply import the module and call it just as you would from the command line.
-# You can pass all the arguments you can also pass in the command line.
 # The evaluation during training works in the full DDP setup.
 from evaluation import cli_evaluate
 args = argparse.Namespace(
@@ -163,10 +171,9 @@ Once you've trained a **nanoVLM** model, you might want to share it on the Huggi
 model.push_to_hub("my-awesome-nanovlm-model")
 ```
 
-The model will be saved on the Hub as a config file `config.json` and a weights file `model.safetensors`. A modelcard `README.md` will also be generated for you with some high-level information. Feel free to update it manually to explain your work.
+The model will be saved on the Hub as a config file `config.json` and a weights file `model.safetensors`. A model card `README.md` will also be generated for you with some high-level information. Feel free to update it manually to explain your work.
 
 If the repo does not exist, it will be created for you. By default the repo will be public. You can pass `private=True` if you don't want to share publicly.
-
 
 ### Local save/load
 
@@ -214,16 +221,18 @@ Batch Size 512: OOM (Peak before OOM: 80247.67 MB)
 Note that the VRAM measurement was performed on a small setup using 'SmolLM2-135M' with a maximum input sequence length of 128 tokens. This may differ from the current default configuration in the project.
 
 **Key Takeaways:**
+
 - You'll need at least ~4.5 GB of VRAM to train the default model even with a batch size of 1.
 - With approximately 8 GB of VRAM, you should be able to train with a batch size of up to 16.
 
 **Measure for Your Setup:**
 
-The values above are for the default model configuration. If you modify the model architecture (e.g., change backbones, hidden sizes) or use different sequence lengths, your VRAM requirements will change. 
+The values above are for the default model configuration. If you modify the model architecture (e.g., change backbones, hidden sizes) or use different sequence lengths, your VRAM requirements will change.
 
-We provide a script `measure_vram.py` that allows you to test VRAM requirements on your specific machine and for your chosen model configuration and batch sizes. 
+We provide a script `measure_vram.py` that allows you to test VRAM requirements on your specific machine and for your chosen model configuration and batch sizes.
 
 To use it:
+
 1. Ensure you have a CUDA-enabled GPU and PyTorch installed.
 2. Run the script with your desired batch sizes. You can also specify a model checkpoint if you have one, or let it initialize a new model based on the default `VLMConfig`.
 
@@ -238,29 +247,29 @@ python measure_vram.py --vlm_checkpoint_path path/to/your/model.pth --batch_size
 
 This script will output the peak VRAM allocated for each batch size tested, helping you determine feasible training configurations for your hardware.
 
-
 ## Contributing
 
 We welcome contributions to nanoVLM! However, to maintain the repository's focus on simplicity and pure PyTorch, we have a few guidelines:
 
-*   **Pure PyTorch:** We aim to keep nanoVLM as a lightweight implementation in pure PyTorch. Contributions that introduce dependencies like `transformers.Trainer`, `accelerate`, or `deepspeed` will not be accepted.
-*   **New Features:** If you have an idea for a new feature, please open an issue first to discuss the scope and implementation details. This helps ensure that your contribution aligns with the project's goals.
-*   **Bug Fixes:** Feel free to submit pull requests for bug fixes.
+- **Pure PyTorch:** We aim to keep nanoVLM as a lightweight implementation in pure PyTorch. Contributions that introduce dependencies like `transformers.Trainer`, `accelerate`, or `deepspeed` will not be accepted.
+- **New Features:** If you have an idea for a new feature, please open an issue first to discuss the scope and implementation details. This helps ensure that your contribution aligns with the project's goals.
+- **Bug Fixes:** Feel free to submit pull requests for bug fixes.
 
 ### Roadmap
 
 Here are some areas we're looking to work on in the near future. Contributions in these areas are particularly welcome:
 
-*   **Evaluations:** Implementing more evaluations or improving our MMStar implementation (highly valued)
-*   **Data Packing:** Implementing a way to create packs of a given size from the input data to optimize training.
-*   **Multi-gpu training:** Training on several GPUs
-*   **Multi-image support:** Training with several images
-*   **Image-splitting:** Enabling higher resolutions through image-splitting as done in SmolVLM.
-*   **VLMEvalKit:** Integration into [VLMEvalKit](https://github.com/open-compass/VLMEvalKit) to enable further benchmarks
+- **Evaluations:** Implementing more evaluations or improving our MMStar implementation (highly valued)
+- **Data Packing:** Implementing a way to create packs of a given size from the input data to optimize training.
+- **Multi-gpu training:** Training on several GPUs
+- **Multi-image support:** Training with several images
+- **Image-splitting:** Enabling higher resolutions through image-splitting as done in SmolVLM.
+- **VLMEvalKit:** Integration into [VLMEvalKit](https://github.com/open-compass/VLMEvalKit) to enable further benchmarks
 
 ## Citation
 
 If you like the project and want to use it somewhere, please use this citation:
+
 ```
 @misc{wiedmann2025nanovlm,
   author = {Luis Wiedmann and Aritra Roy Gosthipaty and Andrés Marafioti},


### PR DESCRIPTION
Small documentation cleanup in README.md to fix typos and remove a duplicated phrase in the lmms-eval section.

- "propably" → "probably" (Sept 9, 2025 note)
- "pull the updated to your local machine" → "pull the updates to your local machine"
- "modelcard" → "model card"
- lmms-eval: remove duplicated phrase in "You can pass all the arguments…"