### PR TITLE
Fix duplicate samples in multi-worker streaming dataloaders

### DIFF
--- a/data/datasets.py
+++ b/data/datasets.py
@@ -106,7 +106,16 @@ class BaseDataset(Dataset):
 
 class VQADataset(BaseDataset):  # Visual Question Answering Dataset
     def iter_for_worker(self):  # with iterable datasets, each worker gets different shards
-        for data in self.dataset:
+        worker_info = torch.utils.data.get_worker_info()
+        worker_dataset = self.dataset
+
+        if worker_info is not None and hasattr(worker_dataset, "shard"):
+            worker_dataset = worker_dataset.shard(
+                num_shards=worker_info.num_workers,
+                index=worker_info.id,
+            )
+
+        for data in worker_dataset:
             yield self._process_data(data)
 
     def __getitem__(self, idx):

--- a/data/datasets.py
+++ b/data/datasets.py
@@ -1,3 +1,4 @@
+import itertools
 import torch
 from PIL import Image
 from torch.utils.data import Dataset
@@ -107,12 +108,19 @@ class BaseDataset(Dataset):
 class VQADataset(BaseDataset):  # Visual Question Answering Dataset
     def iter_for_worker(self):  # with iterable datasets, each worker gets different shards
         worker_info = torch.utils.data.get_worker_info()
-        worker_dataset = self.dataset
-
-        if worker_info is not None and hasattr(worker_dataset, "shard"):
-            worker_dataset = worker_dataset.shard(
+        if worker_info is None:
+            worker_dataset = self.dataset
+        elif hasattr(self.dataset, "shard"):
+            worker_dataset = self.dataset.shard(
                 num_shards=worker_info.num_workers,
                 index=worker_info.id,
+            )
+        else:
+            worker_dataset = itertools.islice(
+                self.dataset,
+                worker_info.id,
+                None,
+                worker_info.num_workers,
             )
 
         for data in worker_dataset:

--- a/tests/benchmark_worker_sharding.py
+++ b/tests/benchmark_worker_sharding.py
@@ -1,74 +1,20 @@
 import argparse
+import multiprocessing
 import sys
 import time
-import types
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import patch
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-stub_processors = types.ModuleType("data.processors")
-stub_processors.get_image_string = lambda tokenizer, counts, mp_len: ""
-sys.modules.setdefault("data.processors", stub_processors)
-
-from data.datasets import VQADataset
-
-
-class FakeTokenizer:
-    image_token = "<image>"
-    pad_token_id = 0
-
-    def apply_chat_template(
-        self, messages, tokenize=False, add_special_tokens=False, return_dict=False
-    ):
-        if not tokenize:
-            return "".join(message["content"] for message in messages)
-
-        tokens = []
-        for message in messages:
-            if message["role"] == "user":
-                tokens.append(1)
-            else:
-                tokens.append(int(message["content"]))
-
-        if return_dict:
-            return {"input_ids": tokens, "attention_mask": [1] * len(tokens)}
-        return tokens
-
-    def encode(self, text):
-        if not text:
-            return []
-        return [99]
-
-
-class FakeStreamingDataset:
-    def __init__(self, sample_ids):
-        self.sample_ids = list(sample_ids)
-
-    def __iter__(self):
-        for sample_id in self.sample_ids:
-            yield {
-                "images": None,
-                "texts": [{"user": f"user-{sample_id}", "assistant": str(sample_id)}],
-            }
-
-    def shard(self, num_shards, index):
-        return FakeStreamingDataset(self.sample_ids[index::num_shards])
-
-
-class LegacyVQADataset(VQADataset):
-    def iter_for_worker(self):
-        for data in self.dataset:
-            yield self._process_data(data)
-
-
-class FakeWorkerInfo:
-    def __init__(self, worker_id, num_workers):
-        self.id = worker_id
-        self.num_workers = num_workers
+from tests.worker_sharding_utils import (
+    FakeStreamingDataset,
+    LegacyVQADataset,
+    VQADataset,
+    collect_ids_with_dataloader,
+)
 
 
 @dataclass
@@ -92,14 +38,7 @@ class BenchmarkStats:
         return self.total_processed / self.unique_processed if self.unique_processed else 0.0
 
 
-def collect_seen_ids(dataset, worker_id, num_workers):
-    worker_info = FakeWorkerInfo(worker_id, num_workers)
-    with patch("torch.utils.data.get_worker_info", return_value=worker_info):
-        return [int(batch["input_ids"][1].item()) for batch in dataset.iter_for_worker()]
-
-
 def run_case(dataset_cls, num_workers, samples_per_repeat, repeats):
-    tokenizer = FakeTokenizer()
     total_processed = 0
     unique_processed = set()
 
@@ -107,17 +46,13 @@ def run_case(dataset_cls, num_workers, samples_per_repeat, repeats):
     for repeat in range(repeats):
         start_id = 2 + repeat * samples_per_repeat
         sample_ids = list(range(start_id, start_id + samples_per_repeat))
-        dataset = dataset_cls(
+        seen_ids = collect_ids_with_dataloader(
+            dataset_cls,
             FakeStreamingDataset(sample_ids),
-            tokenizer,
-            image_processor=None,
-            mp_image_token_length=1,
+            num_workers=num_workers,
         )
-
-        for worker_id in range(num_workers):
-            seen_ids = collect_seen_ids(dataset, worker_id, num_workers)
-            total_processed += len(seen_ids)
-            unique_processed.update(seen_ids)
+        total_processed += len(seen_ids)
+        unique_processed.update(seen_ids)
 
     elapsed_s = time.perf_counter() - start
     return BenchmarkStats(
@@ -141,13 +76,18 @@ def print_stats(stats):
 
 
 def main():
+    multiprocessing.freeze_support()
     parser = argparse.ArgumentParser(
-        description="CPU benchmark for worker sharding behavior in VQADataset.iter_for_worker()."
+        description="Benchmark real multi-worker DataLoader behavior for VQADataset.iter_for_worker()."
     )
     parser.add_argument("--workers", type=int, default=4)
     parser.add_argument("--samples", type=int, default=2000)
     parser.add_argument("--repeats", type=int, default=5)
     args = parser.parse_args()
+
+    print(
+        f"Running benchmark with workers={args.workers}, samples={args.samples}, repeats={args.repeats}"
+    )
 
     legacy_stats = run_case(
         LegacyVQADataset,

--- a/tests/benchmark_worker_sharding.py
+++ b/tests/benchmark_worker_sharding.py
@@ -1,0 +1,174 @@
+import argparse
+import sys
+import time
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+stub_processors = types.ModuleType("data.processors")
+stub_processors.get_image_string = lambda tokenizer, counts, mp_len: ""
+sys.modules.setdefault("data.processors", stub_processors)
+
+from data.datasets import VQADataset
+
+
+class FakeTokenizer:
+    image_token = "<image>"
+    pad_token_id = 0
+
+    def apply_chat_template(
+        self, messages, tokenize=False, add_special_tokens=False, return_dict=False
+    ):
+        if not tokenize:
+            return "".join(message["content"] for message in messages)
+
+        tokens = []
+        for message in messages:
+            if message["role"] == "user":
+                tokens.append(1)
+            else:
+                tokens.append(int(message["content"]))
+
+        if return_dict:
+            return {"input_ids": tokens, "attention_mask": [1] * len(tokens)}
+        return tokens
+
+    def encode(self, text):
+        if not text:
+            return []
+        return [99]
+
+
+class FakeStreamingDataset:
+    def __init__(self, sample_ids):
+        self.sample_ids = list(sample_ids)
+
+    def __iter__(self):
+        for sample_id in self.sample_ids:
+            yield {
+                "images": None,
+                "texts": [{"user": f"user-{sample_id}", "assistant": str(sample_id)}],
+            }
+
+    def shard(self, num_shards, index):
+        return FakeStreamingDataset(self.sample_ids[index::num_shards])
+
+
+class LegacyVQADataset(VQADataset):
+    def iter_for_worker(self):
+        for data in self.dataset:
+            yield self._process_data(data)
+
+
+class FakeWorkerInfo:
+    def __init__(self, worker_id, num_workers):
+        self.id = worker_id
+        self.num_workers = num_workers
+
+
+@dataclass
+class BenchmarkStats:
+    name: str
+    total_processed: int
+    unique_processed: int
+    duplicates: int
+    elapsed_s: float
+
+    @property
+    def raw_samples_per_s(self):
+        return self.total_processed / self.elapsed_s if self.elapsed_s else 0.0
+
+    @property
+    def effective_samples_per_s(self):
+        return self.unique_processed / self.elapsed_s if self.elapsed_s else 0.0
+
+    @property
+    def duplicate_factor(self):
+        return self.total_processed / self.unique_processed if self.unique_processed else 0.0
+
+
+def collect_seen_ids(dataset, worker_id, num_workers):
+    worker_info = FakeWorkerInfo(worker_id, num_workers)
+    with patch("torch.utils.data.get_worker_info", return_value=worker_info):
+        return [int(batch["input_ids"][1].item()) for batch in dataset.iter_for_worker()]
+
+
+def run_case(dataset_cls, num_workers, samples_per_repeat, repeats):
+    tokenizer = FakeTokenizer()
+    total_processed = 0
+    unique_processed = set()
+
+    start = time.perf_counter()
+    for repeat in range(repeats):
+        start_id = 2 + repeat * samples_per_repeat
+        sample_ids = list(range(start_id, start_id + samples_per_repeat))
+        dataset = dataset_cls(
+            FakeStreamingDataset(sample_ids),
+            tokenizer,
+            image_processor=None,
+            mp_image_token_length=1,
+        )
+
+        for worker_id in range(num_workers):
+            seen_ids = collect_seen_ids(dataset, worker_id, num_workers)
+            total_processed += len(seen_ids)
+            unique_processed.update(seen_ids)
+
+    elapsed_s = time.perf_counter() - start
+    return BenchmarkStats(
+        name=dataset_cls.__name__,
+        total_processed=total_processed,
+        unique_processed=len(unique_processed),
+        duplicates=total_processed - len(unique_processed),
+        elapsed_s=elapsed_s,
+    )
+
+
+def print_stats(stats):
+    print(f"{stats.name}:")
+    print(f"  elapsed_s:            {stats.elapsed_s:.6f}")
+    print(f"  total_processed:      {stats.total_processed}")
+    print(f"  unique_processed:     {stats.unique_processed}")
+    print(f"  duplicates:           {stats.duplicates}")
+    print(f"  duplicate_factor:     {stats.duplicate_factor:.2f}x")
+    print(f"  raw_samples_per_s:    {stats.raw_samples_per_s:.2f}")
+    print(f"  effective_samples/s:  {stats.effective_samples_per_s:.2f}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="CPU benchmark for worker sharding behavior in VQADataset.iter_for_worker()."
+    )
+    parser.add_argument("--workers", type=int, default=4)
+    parser.add_argument("--samples", type=int, default=2000)
+    parser.add_argument("--repeats", type=int, default=5)
+    args = parser.parse_args()
+
+    legacy_stats = run_case(
+        LegacyVQADataset,
+        num_workers=args.workers,
+        samples_per_repeat=args.samples,
+        repeats=args.repeats,
+    )
+    current_stats = run_case(
+        VQADataset,
+        num_workers=args.workers,
+        samples_per_repeat=args.samples,
+        repeats=args.repeats,
+    )
+
+    print_stats(legacy_stats)
+    print_stats(current_stats)
+
+    if legacy_stats.effective_samples_per_s:
+        improvement = current_stats.effective_samples_per_s / legacy_stats.effective_samples_per_s
+        print(f"effective_samples/s improvement: {improvement:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_worker_sharding_train_path.py
+++ b/tests/smoke_worker_sharding_train_path.py
@@ -1,0 +1,280 @@
+import argparse
+import multiprocessing
+import os
+import sys
+import time
+from dataclasses import dataclass
+from itertools import islice
+from pathlib import Path
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.utils.data import DataLoader
+
+from data.advanced_datasets import ConstantLengthDataset
+from data.collators import VQACollator
+from tests.worker_sharding_utils import (
+    FakeStreamingDataset,
+    LegacyVQADataset,
+    VQADataset,
+    make_vqa_dataset,
+)
+
+
+@dataclass
+class SmokeStats:
+    name: str
+    warmup_s: float
+    train_s: float
+    scan_s: float
+    trained_batches: int
+    total_seen: int
+    unique_seen: int
+    duplicates: int
+
+    @property
+    def duplicate_factor(self):
+        return self.total_seen / self.unique_seen if self.unique_seen else 0.0
+
+
+class TinyLanguageModel(nn.Module):
+    def __init__(self, vocab_size, hidden_dim=32):
+        super().__init__()
+        self.embedding = nn.Embedding(vocab_size, hidden_dim)
+        self.proj = nn.Linear(hidden_dim, vocab_size)
+
+    def forward(self, input_ids, labels):
+        logits = self.proj(self.embedding(input_ids))
+        return F.cross_entropy(
+            logits.view(-1, logits.size(-1)),
+            labels.view(-1),
+            ignore_index=-100,
+        )
+
+
+def synchronize(device):
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def build_loader(dataset_cls, sample_ids, num_workers, batch_size, seq_length):
+    vqa_dataset = make_vqa_dataset(dataset_cls, FakeStreamingDataset(sample_ids))
+    train_dataset = ConstantLengthDataset(
+        vqa_dataset,
+        infinite=False,
+        max_sample_length=16,
+        seq_length=seq_length,
+        num_of_sequences=batch_size * 4,
+        queue_size=2,
+        max_images_per_example=1,
+        max_images_per_knapsack=8,
+    )
+    collator = VQACollator(vqa_dataset.tokenizer, max_length=seq_length)
+    generator = torch.Generator()
+    generator.manual_seed(0)
+    return DataLoader(
+        train_dataset,
+        batch_size=batch_size,
+        collate_fn=collator,
+        num_workers=num_workers,
+        pin_memory=device_is_cuda(),
+        persistent_workers=False,
+        drop_last=False,
+        generator=generator,
+    )
+
+
+def device_is_cuda():
+    return torch.cuda.is_available()
+
+
+def extract_sample_ids(batch):
+    sample_ids = []
+    for sequence in batch["input_ids"]:
+        tokens = sequence.tolist()
+        for previous_token, current_token in zip(tokens, tokens[1:]):
+            if previous_token == 1 and current_token not in (0, 1):
+                sample_ids.append(int(current_token))
+    return sample_ids
+
+
+def run_training_steps(dataset_cls, sample_ids, num_workers, batch_size, seq_length, steps, device):
+    loader = build_loader(dataset_cls, sample_ids, num_workers, batch_size, seq_length)
+    iterator = iter(loader)
+
+    synchronize(device)
+    warmup_start = time.perf_counter()
+    first_batch = next(iterator)
+    synchronize(device)
+    warmup_s = time.perf_counter() - warmup_start
+
+    vocab_size = max(sample_ids) + 32
+    model = TinyLanguageModel(vocab_size=vocab_size).to(device)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+
+    train_batches = [first_batch, *list(islice(iterator, max(steps - 1, 0)))]
+
+    synchronize(device)
+    train_start = time.perf_counter()
+    for batch in train_batches:
+        input_ids = batch["input_ids"].to(device)
+        labels = batch["labels"].to(device)
+        loss = model(input_ids, labels)
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+    synchronize(device)
+    train_s = time.perf_counter() - train_start
+
+    return warmup_s, train_s, len(train_batches)
+
+
+def scan_loader(dataset_cls, sample_ids, num_workers, batch_size, seq_length):
+    loader = build_loader(dataset_cls, sample_ids, num_workers, batch_size, seq_length)
+    seen_ids = []
+
+    scan_start = time.perf_counter()
+    for batch in loader:
+        seen_ids.extend(extract_sample_ids(batch))
+    scan_s = time.perf_counter() - scan_start
+    return seen_ids, scan_s
+
+
+def run_case(dataset_cls, sample_ids, num_workers, batch_size, seq_length, steps, device):
+    warmup_s, train_s, trained_batches = run_training_steps(
+        dataset_cls,
+        sample_ids,
+        num_workers,
+        batch_size,
+        seq_length,
+        steps,
+        device,
+    )
+    seen_ids, scan_s = scan_loader(
+        dataset_cls,
+        sample_ids,
+        num_workers,
+        batch_size,
+        seq_length,
+    )
+
+    unique_seen = len(set(seen_ids))
+    return SmokeStats(
+        name=dataset_cls.__name__,
+        warmup_s=warmup_s,
+        train_s=train_s,
+        scan_s=scan_s,
+        trained_batches=trained_batches,
+        total_seen=len(seen_ids),
+        unique_seen=unique_seen,
+        duplicates=len(seen_ids) - unique_seen,
+    )
+
+
+def print_stats(stats):
+    print(f"{stats.name}:")
+    print(f"  warmup_s:          {stats.warmup_s:.3f}")
+    print(f"  train_s:           {stats.train_s:.3f}")
+    print(f"  scan_s:            {stats.scan_s:.3f}")
+    print(f"  trained_batches:   {stats.trained_batches}")
+    print(f"  total_seen:        {stats.total_seen}")
+    print(f"  unique_seen:       {stats.unique_seen}")
+    print(f"  duplicates:        {stats.duplicates}")
+    print(f"  duplicate_factor:  {stats.duplicate_factor:.2f}x")
+
+
+def validate_stats(stats, expected_unique, expected_duplicate_factor):
+    if stats.unique_seen != expected_unique:
+        raise AssertionError(
+            f"{stats.name} expected {expected_unique} unique samples, saw {stats.unique_seen}"
+        )
+    if round(stats.duplicate_factor, 2) != round(expected_duplicate_factor, 2):
+        raise AssertionError(
+            f"{stats.name} expected duplicate factor {expected_duplicate_factor:.2f}x, "
+            f"saw {stats.duplicate_factor:.2f}x"
+        )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Smoke-test the real training data path with multi-worker sharding."
+    )
+    parser.add_argument("--workers", type=int, default=3)
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--samples", type=int, default=96)
+    parser.add_argument("--seq-length", type=int, default=24)
+    parser.add_argument("--steps", type=int, default=2)
+    parser.add_argument("--device", choices=("auto", "cpu", "cuda"), default="auto")
+    return parser.parse_args()
+
+
+def resolve_device(device_arg):
+    if device_arg == "cpu":
+        return torch.device("cpu")
+    if device_arg == "cuda":
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA was requested but is not available.")
+        return torch.device("cuda")
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def main():
+    multiprocessing.freeze_support()
+    args = parse_args()
+    device = resolve_device(args.device)
+    torch.manual_seed(0)
+
+    sample_ids = list(range(100, 100 + args.samples))
+    print(
+        "Running smoke test with "
+        f"device={device}, workers={args.workers}, batch_size={args.batch_size}, "
+        f"samples={args.samples}, seq_length={args.seq_length}, steps={args.steps}"
+    )
+
+    overall_start = time.perf_counter()
+    legacy_stats = run_case(
+        LegacyVQADataset,
+        sample_ids,
+        args.workers,
+        args.batch_size,
+        args.seq_length,
+        args.steps,
+        device,
+    )
+    current_stats = run_case(
+        VQADataset,
+        sample_ids,
+        args.workers,
+        args.batch_size,
+        args.seq_length,
+        args.steps,
+        device,
+    )
+    total_s = time.perf_counter() - overall_start
+
+    print_stats(legacy_stats)
+    print_stats(current_stats)
+
+    validate_stats(
+        legacy_stats,
+        expected_unique=len(sample_ids),
+        expected_duplicate_factor=args.workers,
+    )
+    validate_stats(
+        current_stats,
+        expected_unique=len(sample_ids),
+        expected_duplicate_factor=1.0,
+    )
+
+    print(f"total_runtime_s:    {total_s:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_worker_sharding.py
+++ b/tests/test_worker_sharding.py
@@ -1,102 +1,75 @@
-import sys
-import types
+import multiprocessing
 import unittest
-from unittest.mock import patch
+from collections import Counter
 
-
-stub_processors = types.ModuleType("data.processors")
-stub_processors.get_image_string = lambda tokenizer, counts, mp_len: ""
-sys.modules.setdefault("data.processors", stub_processors)
-
-from data.datasets import VQADataset
-
-
-class FakeTokenizer:
-    image_token = "<image>"
-    pad_token_id = 0
-
-    def apply_chat_template(
-        self, messages, tokenize=False, add_special_tokens=False, return_dict=False
-    ):
-        if not tokenize:
-            return "".join(message["content"] for message in messages)
-
-        tokens = []
-        for message in messages:
-            if message["role"] == "user":
-                tokens.append(1)
-            else:
-                tokens.append(int(message["content"]))
-
-        if return_dict:
-            return {"input_ids": tokens, "attention_mask": [1] * len(tokens)}
-        return tokens
-
-    def encode(self, text):
-        if not text:
-            return []
-        return [99]
-
-
-class FakeStreamingDataset:
-    def __init__(self, sample_ids):
-        self.sample_ids = list(sample_ids)
-
-    def __iter__(self):
-        for sample_id in self.sample_ids:
-            yield {
-                "images": None,
-                "texts": [{"user": f"user-{sample_id}", "assistant": str(sample_id)}],
-            }
-
-    def shard(self, num_shards, index):
-        return FakeStreamingDataset(self.sample_ids[index::num_shards])
-
-
-class FakeWorkerInfo:
-    def __init__(self, worker_id, num_workers):
-        self.id = worker_id
-        self.num_workers = num_workers
-
-
-def make_dataset(sample_ids):
-    return VQADataset(
-        FakeStreamingDataset(sample_ids),
-        FakeTokenizer(),
-        image_processor=None,
-        mp_image_token_length=1,
-    )
-
-
-def collect_seen_ids(dataset, worker_id, num_workers):
-    worker_info = FakeWorkerInfo(worker_id, num_workers)
-    with patch("torch.utils.data.get_worker_info", return_value=worker_info):
-        return [int(batch["input_ids"][1].item()) for batch in dataset.iter_for_worker()]
+from tests.worker_sharding_utils import (
+    FakeStreamingDataset,
+    LegacyVQADataset,
+    NonShardableStreamingDataset,
+    VQADataset,
+    collect_ids_with_dataloader,
+)
 
 
 class TestWorkerSharding(unittest.TestCase):
-    def test_streaming_dataset_is_not_duplicated_across_workers(self):
-        sample_ids = list(range(2, 10))
-        dataset = make_dataset(sample_ids)
-
-        worker_zero_ids = collect_seen_ids(dataset, worker_id=0, num_workers=2)
-        worker_one_ids = collect_seen_ids(dataset, worker_id=1, num_workers=2)
+    def assert_seen_once(self, seen_ids, sample_ids):
+        sample_counts = Counter(seen_ids)
 
         self.assertEqual(
-            len(worker_zero_ids) + len(worker_one_ids),
+            len(seen_ids),
             len(sample_ids),
-            f"Expected each base sample exactly once, saw worker 0={worker_zero_ids}, worker 1={worker_one_ids}",
+            f"Expected {len(sample_ids)} samples once each, saw {len(seen_ids)} items: {seen_ids}",
         )
         self.assertEqual(
-            set(worker_zero_ids).union(worker_one_ids),
+            set(seen_ids),
             set(sample_ids),
-            f"Expected all base samples to be covered, saw worker 0={worker_zero_ids}, worker 1={worker_one_ids}",
+            f"Expected all samples to be covered, saw {seen_ids}",
         )
         self.assertTrue(
-            set(worker_zero_ids).isdisjoint(worker_one_ids),
-            f"Expected worker shards to be disjoint, saw worker 0={worker_zero_ids}, worker 1={worker_one_ids}",
+            all(count == 1 for count in sample_counts.values()),
+            f"Expected no duplicate samples, saw counts={dict(sample_counts)}",
         )
+
+    def test_legacy_behavior_duplicates_samples_across_workers(self):
+        sample_ids = list(range(2, 10))
+        seen_ids = collect_ids_with_dataloader(
+            LegacyVQADataset,
+            FakeStreamingDataset(sample_ids),
+            num_workers=2,
+        )
+        sample_counts = Counter(seen_ids)
+
+        self.assertEqual(
+            len(seen_ids),
+            len(sample_ids) * 2,
+            f"Expected each worker to read the full stream before the fix, saw {seen_ids}",
+        )
+        self.assertTrue(
+            any(count > 1 for count in sample_counts.values()),
+            f"Expected duplicate samples before the fix, saw counts={dict(sample_counts)}",
+        )
+
+    def test_shardable_streaming_dataset_is_not_duplicated_across_workers(self):
+        sample_ids = list(range(2, 10))
+        seen_ids = collect_ids_with_dataloader(
+            VQADataset,
+            FakeStreamingDataset(sample_ids),
+            num_workers=2,
+        )
+
+        self.assert_seen_once(seen_ids, sample_ids)
+
+    def test_non_shardable_streaming_dataset_falls_back_to_stride_sharding(self):
+        sample_ids = list(range(2, 14))
+        seen_ids = collect_ids_with_dataloader(
+            VQADataset,
+            NonShardableStreamingDataset(sample_ids),
+            num_workers=3,
+        )
+
+        self.assert_seen_once(seen_ids, sample_ids)
 
 
 if __name__ == "__main__":
+    multiprocessing.freeze_support()
     unittest.main()

--- a/tests/test_worker_sharding.py
+++ b/tests/test_worker_sharding.py
@@ -1,0 +1,102 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+stub_processors = types.ModuleType("data.processors")
+stub_processors.get_image_string = lambda tokenizer, counts, mp_len: ""
+sys.modules.setdefault("data.processors", stub_processors)
+
+from data.datasets import VQADataset
+
+
+class FakeTokenizer:
+    image_token = "<image>"
+    pad_token_id = 0
+
+    def apply_chat_template(
+        self, messages, tokenize=False, add_special_tokens=False, return_dict=False
+    ):
+        if not tokenize:
+            return "".join(message["content"] for message in messages)
+
+        tokens = []
+        for message in messages:
+            if message["role"] == "user":
+                tokens.append(1)
+            else:
+                tokens.append(int(message["content"]))
+
+        if return_dict:
+            return {"input_ids": tokens, "attention_mask": [1] * len(tokens)}
+        return tokens
+
+    def encode(self, text):
+        if not text:
+            return []
+        return [99]
+
+
+class FakeStreamingDataset:
+    def __init__(self, sample_ids):
+        self.sample_ids = list(sample_ids)
+
+    def __iter__(self):
+        for sample_id in self.sample_ids:
+            yield {
+                "images": None,
+                "texts": [{"user": f"user-{sample_id}", "assistant": str(sample_id)}],
+            }
+
+    def shard(self, num_shards, index):
+        return FakeStreamingDataset(self.sample_ids[index::num_shards])
+
+
+class FakeWorkerInfo:
+    def __init__(self, worker_id, num_workers):
+        self.id = worker_id
+        self.num_workers = num_workers
+
+
+def make_dataset(sample_ids):
+    return VQADataset(
+        FakeStreamingDataset(sample_ids),
+        FakeTokenizer(),
+        image_processor=None,
+        mp_image_token_length=1,
+    )
+
+
+def collect_seen_ids(dataset, worker_id, num_workers):
+    worker_info = FakeWorkerInfo(worker_id, num_workers)
+    with patch("torch.utils.data.get_worker_info", return_value=worker_info):
+        return [int(batch["input_ids"][1].item()) for batch in dataset.iter_for_worker()]
+
+
+class TestWorkerSharding(unittest.TestCase):
+    def test_streaming_dataset_is_not_duplicated_across_workers(self):
+        sample_ids = list(range(2, 10))
+        dataset = make_dataset(sample_ids)
+
+        worker_zero_ids = collect_seen_ids(dataset, worker_id=0, num_workers=2)
+        worker_one_ids = collect_seen_ids(dataset, worker_id=1, num_workers=2)
+
+        self.assertEqual(
+            len(worker_zero_ids) + len(worker_one_ids),
+            len(sample_ids),
+            f"Expected each base sample exactly once, saw worker 0={worker_zero_ids}, worker 1={worker_one_ids}",
+        )
+        self.assertEqual(
+            set(worker_zero_ids).union(worker_one_ids),
+            set(sample_ids),
+            f"Expected all base samples to be covered, saw worker 0={worker_zero_ids}, worker 1={worker_one_ids}",
+        )
+        self.assertTrue(
+            set(worker_zero_ids).isdisjoint(worker_one_ids),
+            f"Expected worker shards to be disjoint, saw worker 0={worker_zero_ids}, worker 1={worker_one_ids}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/worker_sharding_utils.py
+++ b/tests/worker_sharding_utils.py
@@ -1,0 +1,97 @@
+import sys
+import types
+from pathlib import Path
+
+from torch.utils.data import DataLoader, IterableDataset
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+stub_processors = types.ModuleType("data.processors")
+stub_processors.get_image_string = lambda tokenizer, counts, mp_len: ""
+sys.modules.setdefault("data.processors", stub_processors)
+
+from data.datasets import VQADataset
+
+
+class FakeTokenizer:
+    image_token = "<image>"
+    pad_token_id = 0
+
+    def apply_chat_template(
+        self, messages, tokenize=False, add_special_tokens=False, return_dict=False
+    ):
+        if not tokenize:
+            return "".join(message["content"] for message in messages)
+
+        tokens = []
+        for message in messages:
+            if message["role"] == "user":
+                tokens.append(1)
+            else:
+                tokens.append(int(message["content"]))
+
+        if return_dict:
+            return {"input_ids": tokens, "attention_mask": [1] * len(tokens)}
+        return tokens
+
+    def encode(self, text):
+        if not text:
+            return []
+        return [99]
+
+
+class _BaseFakeStreamingDataset:
+    def __init__(self, sample_ids):
+        self.sample_ids = list(sample_ids)
+
+    def __iter__(self):
+        for sample_id in self.sample_ids:
+            yield {
+                "images": None,
+                "texts": [{"user": f"user-{sample_id}", "assistant": str(sample_id)}],
+            }
+
+
+class FakeStreamingDataset(_BaseFakeStreamingDataset):
+    def shard(self, num_shards, index):
+        return FakeStreamingDataset(self.sample_ids[index::num_shards])
+
+
+class NonShardableStreamingDataset(_BaseFakeStreamingDataset):
+    pass
+
+
+class LegacyVQADataset(VQADataset):
+    def iter_for_worker(self):
+        for data in self.dataset:
+            yield self._process_data(data)
+
+
+class WorkerIterableDataset(IterableDataset):
+    def __init__(self, dataset):
+        self.dataset = dataset
+
+    def __iter__(self):
+        yield from self.dataset.iter_for_worker()
+
+
+def make_vqa_dataset(dataset_cls, base_dataset):
+    return dataset_cls(
+        base_dataset,
+        FakeTokenizer(),
+        image_processor=None,
+        mp_image_token_length=1,
+    )
+
+
+def collect_ids_with_dataloader(dataset_cls, base_dataset, num_workers):
+    dataset = WorkerIterableDataset(make_vqa_dataset(dataset_cls, base_dataset))
+    loader = DataLoader(
+        dataset,
+        batch_size=None,
+        num_workers=num_workers,
+        persistent_workers=False,
+    )
+    return [int(sample["input_ids"][1].item()) for sample in loader]


### PR DESCRIPTION
This PR fixes the worker-sharding bug from #200.

When `VQADataset.iter_for_worker()` was used with a streaming dataset and `DataLoader(num_workers > 1)`, each worker would walk the full stream independently. That meant every sample was processed once per worker instead of once overall.

What changed:
- shard streaming datasets per worker via `.shard(...)` when the underlying dataset supports it
- fall back to stride-based sharding for iterable datasets that do not implement `.shard()`
- add a real multi-worker regression test that reproduces the old duplication and verifies the fixed behavior
- add a small benchmark and a training-path smoke test to compare duplicate counts and effective throughput before vs after the fix

Why this matters:
- it removes duplicated samples during multi-worker streaming training
- it makes effective throughput line up with actual useful sample coverage
- it keeps the fix robust even when the iterable dataset is not a Hugging Face streaming object

Validation:
- `D:\Dev\conda-envs\py313\python.exe -m unittest tests.test_worker_sharding -v`
- `D:\Dev\conda-envs\py313\python.exe tests\benchmark_worker_sharding.py --workers 4 --samples 2000 --repeats 5`
  - before: `40000` processed / `10000` unique / `30000` duplicates / `554.33` effective samples/s
  - after: `10000` processed / `10000` unique / `0` duplicates / `900.49` effective samples/s
- `D:\Dev\conda-envs\py313\python.exe tests\smoke_worker_sharding_train_path.py --device auto`
  - legacy path: `288` total / `96` unique / `192` duplicates / `3.00x`
  - fixed path: `96` total / `96` unique / `0` duplicates / `1.00x`

Fixes #200.
