### PR TITLE
Fix packed sequence position IDs and cross-sample attention

### DIFF
--- a/data/advanced_datasets.py
+++ b/data/advanced_datasets.py
@@ -53,8 +53,9 @@ class ConstantLengthDataset(IterableDataset):
             Iterator[dict]: An iterator that yields training samples with the following structure:
                 - input_ids: Tensor of token ids of shape (seq_length,)
                 - labels: Tensor of labels of shape (seq_length,)
-                - attention_mask: Tensor of attention mask of shape (seq_length, seq_length)
+                - attention_mask: Tensor of attention mask of shape (seq_length,)
                 - position_ids: Tensor of per-token position ids of shape (seq_length,)
+                - document_ids: Tensor of per-token document ids of shape (seq_length,)
                 - images: List of processed image tensors
         """
         worker_info = get_worker_info()
@@ -164,6 +165,7 @@ class ConstantLengthDataset(IterableDataset):
                     "attention_mask": packed[2],
                     "images":         packed[3],
                     "position_ids":   packed[4],
+                    "document_ids":   packed[5],
                 })
 
             if packed_group:
@@ -239,16 +241,11 @@ class ConstantLengthDataset(IterableDataset):
         if len(ids) > max_len:
             raise ValueError(f"Packed length {len(ids)} > max_len {max_len}")
 
-        key_mask = torch.stack(key_mask).to(torch.bool)
-        document_ids = torch.tensor(document_ids, dtype=torch.long)
-        same_document = document_ids.unsqueeze(0) == document_ids.unsqueeze(1)
-        attention_mask = same_document & key_mask.unsqueeze(0)
-        attention_mask |= torch.eye(len(document_ids), dtype=torch.bool)
-
         return (
             torch.stack(ids),
             torch.stack(lbl),
-            attention_mask,
+            torch.stack(key_mask).to(torch.bool),
             ims,
             torch.tensor(position_ids, dtype=torch.long),
+            torch.tensor(document_ids, dtype=torch.long),
         )

--- a/data/advanced_datasets.py
+++ b/data/advanced_datasets.py
@@ -53,7 +53,8 @@ class ConstantLengthDataset(IterableDataset):
             Iterator[dict]: An iterator that yields training samples with the following structure:
                 - input_ids: Tensor of token ids of shape (seq_length,)
                 - labels: Tensor of labels of shape (seq_length,)
-                - attention_mask: Tensor of attention mask of shape (seq_length,)
+                - attention_mask: Tensor of attention mask of shape (seq_length, seq_length)
+                - position_ids: Tensor of per-token position ids of shape (seq_length,)
                 - images: List of processed image tensors
         """
         worker_info = get_worker_info()
@@ -162,6 +163,7 @@ class ConstantLengthDataset(IterableDataset):
                     "labels":         packed[1],
                     "attention_mask": packed[2],
                     "images":         packed[3],
+                    "position_ids":   packed[4],
                 })
 
             if packed_group:
@@ -222,16 +224,31 @@ class ConstantLengthDataset(IterableDataset):
         return [g for g in knapsack_groups if g]
 
     def _pack_one_group(self, group_indices, batch, max_len):
-        ids, lbl, am, ims = [], [], [], []
+        ids, lbl, key_mask, ims = [], [], [], []
+        position_ids, document_ids = [], []
 
-        for i in group_indices:
+        for document_id, i in enumerate(group_indices):
             ids.extend(batch[i]["input_ids"])
             lbl.extend(batch[i]["labels"])
-            am.extend(batch[i]["attention_mask"])
+            key_mask.extend(batch[i]["attention_mask"])
             ims.extend(batch[i]["images"])
+            position_ids.extend(range(len(batch[i]["input_ids"])))
+            document_ids.extend([document_id] * len(batch[i]["input_ids"]))
 
         # safety: assert we never overflow
         if len(ids) > max_len:
             raise ValueError(f"Packed length {len(ids)} > max_len {max_len}")
 
-        return torch.stack(ids), torch.stack(lbl), torch.stack(am), ims
+        key_mask = torch.stack(key_mask).to(torch.bool)
+        document_ids = torch.tensor(document_ids, dtype=torch.long)
+        same_document = document_ids.unsqueeze(0) == document_ids.unsqueeze(1)
+        attention_mask = same_document & key_mask.unsqueeze(0)
+        attention_mask |= torch.eye(len(document_ids), dtype=torch.bool)
+
+        return (
+            torch.stack(ids),
+            torch.stack(lbl),
+            attention_mask,
+            ims,
+            torch.tensor(position_ids, dtype=torch.long),
+        )

--- a/data/collators.py
+++ b/data/collators.py
@@ -5,37 +5,14 @@ class BaseCollator(object):
     def __init__(self, tokenizer):
         self.tokenizer = tokenizer
 
-    def _pad_attention_mask(self, attention_mask, max_length):
-        if attention_mask.dim() == 1:
-            return torch.nn.functional.pad(
-                attention_mask,
-                (max_length - len(attention_mask), 0),
-                value=0,
-            )
-
-        pad_len = max_length - attention_mask.size(0)
-        if pad_len <= 0:
-            return attention_mask
-
-        padded = torch.zeros(
-            (max_length, max_length),
-            dtype=attention_mask.dtype,
-            device=attention_mask.device,
-        )
-        padded[pad_len:, pad_len:] = attention_mask
-        padded[:pad_len, :pad_len] = torch.eye(
-            pad_len,
-            dtype=attention_mask.dtype,
-            device=attention_mask.device,
-        )
-        return padded
-
     def _pad_batch(self, batch, max_length):
         batch["input_ids"] = [torch.nn.functional.pad(ids, (max_length - len(ids), 0), value=self.tokenizer.pad_token_id) for ids in batch["input_ids"]]
         batch["labels"]    = [torch.nn.functional.pad(labels, (max_length - len(labels), 0), value=self.tokenizer.pad_token_id) for labels in batch["labels"]]
-        batch["attention_mask"] = [self._pad_attention_mask(attention_mask, max_length) for attention_mask in batch["attention_mask"]]
+        batch["attention_mask"] = [torch.nn.functional.pad(attention_mask, (max_length - len(attention_mask), 0), value=0) for attention_mask in batch["attention_mask"]]
         if "position_ids" in batch:
             batch["position_ids"] = [torch.nn.functional.pad(position_ids, (max_length - len(position_ids), 0), value=0) for position_ids in batch["position_ids"]]
+        if "document_ids" in batch:
+            batch["document_ids"] = [torch.nn.functional.pad(document_ids, (max_length - len(document_ids), 0), value=-1) for document_ids in batch["document_ids"]]
 
     def prepare_batch(self, batch, max_length=None):
         # 1) Handle empty
@@ -96,9 +73,11 @@ class VQACollator(BaseCollator):  # Visual Question Answering Collator
     def _pad_batch(self, batch, max_length):  # Reimplementing to use -100 as the pad value for labels, so that it's ignored by the loss
         batch["input_ids"] = [torch.nn.functional.pad(ids, (max_length - len(ids), 0), value=self.tokenizer.pad_token_id) for ids in batch["input_ids"]]
         batch["labels"]    = [torch.nn.functional.pad(labels, (max_length - len(labels), 0), value=-100) for labels in batch["labels"]]
-        batch["attention_mask"] = [self._pad_attention_mask(attention_mask, max_length) for attention_mask in batch["attention_mask"]]
+        batch["attention_mask"] = [torch.nn.functional.pad(attention_mask, (max_length - len(attention_mask), 0), value=0) for attention_mask in batch["attention_mask"]]
         if "position_ids" in batch:
             batch["position_ids"] = [torch.nn.functional.pad(position_ids, (max_length - len(position_ids), 0), value=0) for position_ids in batch["position_ids"]]
+        if "document_ids" in batch:
+            batch["document_ids"] = [torch.nn.functional.pad(document_ids, (max_length - len(document_ids), 0), value=-1) for document_ids in batch["document_ids"]]
 
     def __call__(self, batch):
         batch = self.prepare_batch(batch, max_length=self.max_length)

--- a/data/collators.py
+++ b/data/collators.py
@@ -5,10 +5,37 @@ class BaseCollator(object):
     def __init__(self, tokenizer):
         self.tokenizer = tokenizer
 
+    def _pad_attention_mask(self, attention_mask, max_length):
+        if attention_mask.dim() == 1:
+            return torch.nn.functional.pad(
+                attention_mask,
+                (max_length - len(attention_mask), 0),
+                value=0,
+            )
+
+        pad_len = max_length - attention_mask.size(0)
+        if pad_len <= 0:
+            return attention_mask
+
+        padded = torch.zeros(
+            (max_length, max_length),
+            dtype=attention_mask.dtype,
+            device=attention_mask.device,
+        )
+        padded[pad_len:, pad_len:] = attention_mask
+        padded[:pad_len, :pad_len] = torch.eye(
+            pad_len,
+            dtype=attention_mask.dtype,
+            device=attention_mask.device,
+        )
+        return padded
+
     def _pad_batch(self, batch, max_length):
         batch["input_ids"] = [torch.nn.functional.pad(ids, (max_length - len(ids), 0), value=self.tokenizer.pad_token_id) for ids in batch["input_ids"]]
         batch["labels"]    = [torch.nn.functional.pad(labels, (max_length - len(labels), 0), value=self.tokenizer.pad_token_id) for labels in batch["labels"]]
-        batch["attention_mask"] = [torch.nn.functional.pad(attention_mask, (max_length - len(attention_mask), 0), value=0) for attention_mask in batch["attention_mask"]]
+        batch["attention_mask"] = [self._pad_attention_mask(attention_mask, max_length) for attention_mask in batch["attention_mask"]]
+        if "position_ids" in batch:
+            batch["position_ids"] = [torch.nn.functional.pad(position_ids, (max_length - len(position_ids), 0), value=0) for position_ids in batch["position_ids"]]
 
     def prepare_batch(self, batch, max_length=None):
         # 1) Handle empty
@@ -37,23 +64,28 @@ class BaseCollator(object):
             max_len = max(map(len, batch["input_ids"]))
         self._pad_batch(batch, max_len) #  dictionaries in Python are mutable and passed by reference
 
-        return {
-            "input_ids": torch.stack(batch["input_ids"]),
-            "attention_mask": torch.stack(batch["attention_mask"]),
+        prepared_batch = {
             "images": batch["images"],
-            "labels": torch.stack(batch["labels"]),
         }
+        for key, values in batch.items():
+            if key == "images":
+                continue
+            prepared_batch[key] = torch.stack(values)
+
+        return prepared_batch
 
     def _discard_samples_that_are_too_long(self, batch, max_length):
-        filtered = [
-            (ids, label, attn, img)
-            for ids, label, attn, img in zip(batch["input_ids"], batch["labels"], batch["attention_mask"], batch["images"])
+        keep_indices = [
+            index
+            for index, ids in enumerate(batch["input_ids"])
             if len(ids) <= max_length
         ]
-        if not filtered:
-            return {"input_ids": [], "labels": [], "attention_mask": [], "images": []}
-        batch_token_ids, batch_labels, batch_attentions, batch_images = zip(*filtered)
-        return {"input_ids": list(batch_token_ids), "labels": list(batch_labels), "attention_mask": list(batch_attentions), "images": list(batch_images)}
+        if not keep_indices:
+            return {key: [] for key in batch}
+        return {
+            key: [values[index] for index in keep_indices]
+            for key, values in batch.items()
+        }
 
 
 class VQACollator(BaseCollator):  # Visual Question Answering Collator
@@ -64,7 +96,9 @@ class VQACollator(BaseCollator):  # Visual Question Answering Collator
     def _pad_batch(self, batch, max_length):  # Reimplementing to use -100 as the pad value for labels, so that it's ignored by the loss
         batch["input_ids"] = [torch.nn.functional.pad(ids, (max_length - len(ids), 0), value=self.tokenizer.pad_token_id) for ids in batch["input_ids"]]
         batch["labels"]    = [torch.nn.functional.pad(labels, (max_length - len(labels), 0), value=-100) for labels in batch["labels"]]
-        batch["attention_mask"] = [torch.nn.functional.pad(attention_mask, (max_length - len(attention_mask), 0), value=0) for attention_mask in batch["attention_mask"]]
+        batch["attention_mask"] = [self._pad_attention_mask(attention_mask, max_length) for attention_mask in batch["attention_mask"]]
+        if "position_ids" in batch:
+            batch["position_ids"] = [torch.nn.functional.pad(position_ids, (max_length - len(position_ids), 0), value=0) for position_ids in batch["position_ids"]]
 
     def __call__(self, batch):
         batch = self.prepare_batch(batch, max_length=self.max_length)

--- a/eval/measure_vram.py
+++ b/eval/measure_vram.py
@@ -131,11 +131,18 @@ def measure_vram(args, vlm_cfg, train_cfg_defaults):
                 input_ids = batch["input_ids"].to(device)
                 labels = batch["labels"].to(device)
                 attention_mask = batch["attention_mask"].to(device)
+                position_ids = batch["position_ids"].to(device) if "position_ids" in batch else None
 
                 optimizer.zero_grad(set_to_none=True)
 
                 with torch.autocast(device_type='cuda', dtype=torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16): # Doing autocast to stay close the train.py script
-                    _, loss = model(input_ids, images, attention_mask=attention_mask, targets=labels)
+                    _, loss = model(
+                        input_ids,
+                        images,
+                        attention_mask=attention_mask,
+                        targets=labels,
+                        position_ids=position_ids,
+                    )
 
                 if loss is not None:
                     loss.backward()

--- a/eval/measure_vram.py
+++ b/eval/measure_vram.py
@@ -132,6 +132,7 @@ def measure_vram(args, vlm_cfg, train_cfg_defaults):
                 labels = batch["labels"].to(device)
                 attention_mask = batch["attention_mask"].to(device)
                 position_ids = batch["position_ids"].to(device) if "position_ids" in batch else None
+                document_ids = batch["document_ids"].to(device) if "document_ids" in batch else None
 
                 optimizer.zero_grad(set_to_none=True)
 
@@ -142,6 +143,7 @@ def measure_vram(args, vlm_cfg, train_cfg_defaults):
                         attention_mask=attention_mask,
                         targets=labels,
                         position_ids=position_ids,
+                        document_ids=document_ids,
                     )
 
                 if loss is not None:

--- a/models/language_model.py
+++ b/models/language_model.py
@@ -4,24 +4,25 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
-def _to_additive_attention_mask(
+def _to_boolean_attention_mask(
     attention_mask: torch.Tensor | None,
-    q: torch.Tensor,
     T_curr: int,
     T_kv: int,
     document_ids: torch.Tensor | None = None,
-) -> torch.Tensor:
-    """Convert supported mask layouts to an additive mask for attention."""
-    min_value = torch.finfo(q.dtype).min
+    causal: bool = False,
+) -> torch.Tensor | None:
+    """Convert supported mask layouts to a boolean mask for attention."""
+    device = None
+    if attention_mask is not None:
+        device = attention_mask.device
+    elif document_ids is not None:
+        device = document_ids.device
 
     if attention_mask is None:
-        if document_ids is None:
+        if document_ids is None and not causal:
             return None
-        allowed = torch.ones(
-            (document_ids.size(0), 1, T_curr, T_kv),
-            dtype=torch.bool,
-            device=document_ids.device,
-        )
+        batch_size = document_ids.size(0) if document_ids is not None else 1
+        allowed = torch.ones((batch_size, 1, T_curr, T_kv), dtype=torch.bool, device=device)
     elif attention_mask.dim() == 2:
         allowed = attention_mask[:, :T_kv].to(torch.bool).unsqueeze(1).unsqueeze(2)
     elif attention_mask.dim() == 3:
@@ -38,6 +39,50 @@ def _to_additive_attention_mask(
         k_document_ids = document_ids[:, :T_kv]
         same_document = q_document_ids.unsqueeze(-1) == k_document_ids.unsqueeze(-2)
         allowed = allowed & same_document.unsqueeze(1)
+
+    if causal:
+        query_positions = torch.arange(T_kv - T_curr, T_kv, device=device)
+        key_positions = torch.arange(T_kv, device=device)
+        causal_mask = key_positions.unsqueeze(0) <= query_positions.unsqueeze(1)
+        allowed = allowed & causal_mask.view(1, 1, T_curr, T_kv)
+
+    return allowed
+
+
+def _needs_explicit_attention_mask(
+    attention_mask: torch.Tensor | None,
+    T_kv: int,
+    document_ids: torch.Tensor | None = None,
+) -> bool:
+    """Return True when attention needs more than the built-in causal mask."""
+    if document_ids is not None:
+        return True
+    if attention_mask is None:
+        return False
+    if attention_mask.dim() != 2:
+        return True
+    return not torch.all(attention_mask[:, :T_kv].to(torch.bool)).item()
+
+
+def _to_additive_attention_mask(
+    attention_mask: torch.Tensor | None,
+    q: torch.Tensor,
+    T_curr: int,
+    T_kv: int,
+    document_ids: torch.Tensor | None = None,
+    causal: bool = False,
+) -> torch.Tensor | None:
+    """Convert supported mask layouts to an additive mask for attention."""
+    min_value = torch.finfo(q.dtype).min
+    allowed = _to_boolean_attention_mask(
+        attention_mask,
+        T_curr,
+        T_kv,
+        document_ids=document_ids,
+        causal=causal,
+    )
+    if allowed is None:
+        return None
 
     additive_attn_mask = torch.zeros(
         allowed.shape,
@@ -311,33 +356,49 @@ class LanguageModelGroupedQueryAttention(nn.Module):
 
         # Prepare attention mask for SDPA or manual path
         # attention_mask is (B, T_kv_total_length), 1 for attend, 0 for pad
-        additive_attn_mask = None
-        if attention_mask is not None or document_ids is not None:
-            additive_attn_mask = _to_additive_attention_mask(
-                attention_mask,
-                q,
-                T_curr,
-                T_kv,
-                document_ids=document_ids,
-            )
+        needs_explicit_mask = _needs_explicit_attention_mask(
+            attention_mask,
+            T_kv,
+            document_ids=document_ids,
+        )
 
         if self.sdpa and x.device.type != 'mps':
-            # During decode, no additional masking needed as [1, T_kv] is naturally causal
+            # SDPA cannot combine attn_mask with is_causal, so fold causal masking in when needed.
             is_causal = (T_curr == T_kv and T_curr > 1)
+            bool_attn_mask = None
+            if needs_explicit_mask:
+                bool_attn_mask = _to_boolean_attention_mask(
+                    attention_mask,
+                    T_curr,
+                    T_kv,
+                    document_ids=document_ids,
+                    causal=is_causal,
+                )
+                is_causal = False
             y = torch.nn.functional.scaled_dot_product_attention(
                 q, k_exp, v_exp,
-                attn_mask=additive_attn_mask, 
+                attn_mask=bool_attn_mask,
                 dropout_p=self.dropout if self.training else 0.0,
                 is_causal=is_causal
             )
         else:
+            additive_attn_mask = None
+            if needs_explicit_mask:
+                additive_attn_mask = _to_additive_attention_mask(
+                    attention_mask,
+                    q,
+                    T_curr,
+                    T_kv,
+                    document_ids=document_ids,
+                    causal=(T_curr == T_kv and T_curr > 1),
+                )
             # Manual attention implementation
             attn = torch.matmul(q, k_exp.transpose(2, 3)) / math.sqrt(self.head_dim) # (B, n_heads, T_curr, T_kv)
-            # During decode: no additional masking needed as [1, T_kv] is naturally causal
-            if T_curr == T_kv and T_curr > 1:
-                causal_mask_val = torch.tril(torch.ones(T_curr, T_curr, device=x.device, dtype=torch.bool)).view(1, 1, T_curr, T_curr)
+            if additive_attn_mask is None and T_curr == T_kv and T_curr > 1:
+                causal_mask_val = torch.tril(
+                    torch.ones(T_curr, T_curr, device=x.device, dtype=torch.bool)
+                ).view(1, 1, T_curr, T_curr)
                 attn = attn.masked_fill(~causal_mask_val, float('-inf'))
-
             if additive_attn_mask is not None: # Additive padding mask
                 # additive_attn_mask is [B,1,1,T_kv], needs to be broadcast to [B, n_heads, T_curr, T_kv]
                 attn = attn + additive_attn_mask 

--- a/models/language_model.py
+++ b/models/language_model.py
@@ -5,15 +5,24 @@ import torch.nn.functional as F
 
 
 def _to_additive_attention_mask(
-    attention_mask: torch.Tensor,
+    attention_mask: torch.Tensor | None,
     q: torch.Tensor,
     T_curr: int,
     T_kv: int,
+    document_ids: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Convert supported mask layouts to an additive mask for attention."""
     min_value = torch.finfo(q.dtype).min
 
-    if attention_mask.dim() == 2:
+    if attention_mask is None:
+        if document_ids is None:
+            return None
+        allowed = torch.ones(
+            (document_ids.size(0), 1, T_curr, T_kv),
+            dtype=torch.bool,
+            device=document_ids.device,
+        )
+    elif attention_mask.dim() == 2:
         allowed = attention_mask[:, :T_kv].to(torch.bool).unsqueeze(1).unsqueeze(2)
     elif attention_mask.dim() == 3:
         allowed = attention_mask[:, :T_curr, :T_kv].to(torch.bool).unsqueeze(1)
@@ -23,6 +32,12 @@ def _to_additive_attention_mask(
         raise ValueError(
             "attention_mask must have shape [B, T], [B, T_q, T_k], or [B, H/T, T_q, T_k]"
         )
+
+    if document_ids is not None:
+        q_document_ids = document_ids[:, :T_curr]
+        k_document_ids = document_ids[:, :T_kv]
+        same_document = q_document_ids.unsqueeze(-1) == k_document_ids.unsqueeze(-2)
+        allowed = allowed & same_document.unsqueeze(1)
 
     additive_attn_mask = torch.zeros(
         allowed.shape,
@@ -233,7 +248,15 @@ class LanguageModelGroupedQueryAttention(nn.Module):
         if not self.sdpa:
             print("Warning: scaled dot product attention not available, using standard attention in LM.")
 
-    def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, attention_mask=None, block_kv_cache=None) -> tuple[torch.Tensor, dict]:
+    def forward(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        attention_mask=None,
+        block_kv_cache=None,
+        document_ids: torch.Tensor=None,
+    ) -> tuple[torch.Tensor, dict]:
         """
         Forward pass for grouped query attention.
 
@@ -289,12 +312,13 @@ class LanguageModelGroupedQueryAttention(nn.Module):
         # Prepare attention mask for SDPA or manual path
         # attention_mask is (B, T_kv_total_length), 1 for attend, 0 for pad
         additive_attn_mask = None
-        if attention_mask is not None:
+        if attention_mask is not None or document_ids is not None:
             additive_attn_mask = _to_additive_attention_mask(
                 attention_mask,
                 q,
                 T_curr,
                 T_kv,
+                document_ids=document_ids,
             )
 
         if self.sdpa and x.device.type != 'mps':
@@ -386,7 +410,15 @@ class LanguageModelBlock(nn.Module):
         self.norm1 = RMSNorm(cfg) # Input Norm
         self.norm2 = RMSNorm(cfg) # Post Attention Norm
     
-    def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, attention_mask: torch.Tensor=None, block_kv_cache: dict=None):
+    def forward(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        attention_mask: torch.Tensor=None,
+        block_kv_cache: dict=None,
+        document_ids: torch.Tensor=None,
+    ):
         """
         Forward pass of the Transformer block.
 
@@ -406,7 +438,14 @@ class LanguageModelBlock(nn.Module):
         """
         res = x
         x = self.norm1(x)
-        x, block_kv_cache = self.attn(x, cos, sin, attention_mask, block_kv_cache)
+        x, block_kv_cache = self.attn(
+            x,
+            cos,
+            sin,
+            attention_mask,
+            block_kv_cache,
+            document_ids=document_ids,
+        )
         x = res + x
 
         res = x
@@ -453,6 +492,7 @@ class LanguageModel(nn.Module):
         kv_cache: list[dict]=None,
         start_pos: int=0,
         position_ids: torch.Tensor=None,
+        document_ids: torch.Tensor=None,
     ):
         """
         Performs a forward pass through the language model.
@@ -509,6 +549,12 @@ class LanguageModel(nn.Module):
                 raise ValueError(
                     f"position_ids must have shape {(B, T_curr)}, got {tuple(current_position_ids.shape)}"
                 )
+        if document_ids is not None:
+            document_ids = document_ids.to(device=x.device)
+            if document_ids.shape[0] != B or document_ids.shape[1] < T_curr:
+                raise ValueError(
+                    f"document_ids must have shape [B, T] with T >= {T_curr}, got {tuple(document_ids.shape)}"
+                )
         cos, sin = self.rotary_embd(current_position_ids) # Get rotary position embeddings for current tokens
 
         # Initialize new KV cache if none provided
@@ -516,7 +562,14 @@ class LanguageModel(nn.Module):
             kv_cache = [None] * len(self.blocks)
 
         for i, block in enumerate(self.blocks):
-            x, kv_cache[i] = block(x, cos, sin, attention_mask, kv_cache[i])
+            x, kv_cache[i] = block(
+                x,
+                cos,
+                sin,
+                attention_mask,
+                kv_cache[i],
+                document_ids=document_ids,
+            )
 
         x = self.norm(x)
 

--- a/models/language_model.py
+++ b/models/language_model.py
@@ -3,6 +3,35 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+
+def _to_additive_attention_mask(
+    attention_mask: torch.Tensor,
+    q: torch.Tensor,
+    T_curr: int,
+    T_kv: int,
+) -> torch.Tensor:
+    """Convert supported mask layouts to an additive mask for attention."""
+    min_value = torch.finfo(q.dtype).min
+
+    if attention_mask.dim() == 2:
+        allowed = attention_mask[:, :T_kv].to(torch.bool).unsqueeze(1).unsqueeze(2)
+    elif attention_mask.dim() == 3:
+        allowed = attention_mask[:, :T_curr, :T_kv].to(torch.bool).unsqueeze(1)
+    elif attention_mask.dim() == 4:
+        allowed = attention_mask[:, :, :T_curr, :T_kv].to(torch.bool)
+    else:
+        raise ValueError(
+            "attention_mask must have shape [B, T], [B, T_q, T_k], or [B, H/T, T_q, T_k]"
+        )
+
+    additive_attn_mask = torch.zeros(
+        allowed.shape,
+        dtype=q.dtype,
+        device=q.device,
+    )
+    additive_attn_mask = additive_attn_mask.masked_fill(~allowed, min_value)
+    return additive_attn_mask
+
 # https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L69
 class RMSNorm(nn.Module):
     """
@@ -261,11 +290,12 @@ class LanguageModelGroupedQueryAttention(nn.Module):
         # attention_mask is (B, T_kv_total_length), 1 for attend, 0 for pad
         additive_attn_mask = None
         if attention_mask is not None:
-            # The current `attention_mask` parameter is assumed to be `[B, total_sequence_length_kv]`
-            # Let's make it `[B, 1, 1, T_kv]` for SDPA.
-            mask_for_keys = attention_mask[:, :T_kv] # Ensure mask matches key length [B, T_kv]
-            additive_attn_mask = (1.0 - mask_for_keys.unsqueeze(1).unsqueeze(2).float()) * torch.finfo(q.dtype).min
-            # This additive_attn_mask shape is [B, 1, 1, T_kv]
+            additive_attn_mask = _to_additive_attention_mask(
+                attention_mask,
+                q,
+                T_curr,
+                T_kv,
+            )
 
         if self.sdpa and x.device.type != 'mps':
             # During decode, no additional masking needed as [1, T_kv] is naturally causal
@@ -416,7 +446,14 @@ class LanguageModel(nn.Module):
         elif isinstance(module, RMSNorm):
             module.weight.data.fill_(1.0)
 
-    def forward(self, x: torch.Tensor, attention_mask: torch.Tensor=None, kv_cache: list[dict]=None, start_pos: int=0):
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_mask: torch.Tensor=None,
+        kv_cache: list[dict]=None,
+        start_pos: int=0,
+        position_ids: torch.Tensor=None,
+    ):
         """
         Performs a forward pass through the language model.
 
@@ -460,8 +497,18 @@ class LanguageModel(nn.Module):
         # T_curr is the length of the current input sequence
         B, T_curr, _ = x.size()
         
-        # Create position_ids for the current sequence based on start_pos
-        current_position_ids = torch.arange(start_pos, start_pos + T_curr, device=x.device).unsqueeze(0).expand(B, -1)
+        if position_ids is None:
+            current_position_ids = (
+                torch.arange(start_pos, start_pos + T_curr, device=x.device)
+                .unsqueeze(0)
+                .expand(B, -1)
+            )
+        else:
+            current_position_ids = position_ids.to(device=x.device)
+            if current_position_ids.shape != (B, T_curr):
+                raise ValueError(
+                    f"position_ids must have shape {(B, T_curr)}, got {tuple(current_position_ids.shape)}"
+                )
         cos, sin = self.rotary_embd(current_position_ids) # Get rotary position embeddings for current tokens
 
         # Initialize new KV cache if none provided

--- a/models/vision_language_model.py
+++ b/models/vision_language_model.py
@@ -59,7 +59,7 @@ class VisionLanguageModel(nn.Module):
                 return torch.cat(images, dim=0).to(device)
         return images # Already a tensor
 
-    def forward(self, input_ids, images, attention_mask=None, targets=None, position_ids=None):
+    def forward(self, input_ids, images, attention_mask=None, targets=None, position_ids=None, document_ids=None):
         images_tensor = self._process_images(images, input_ids.device)
         token_embd = self.decoder.token_embedding(input_ids) # [B, T_sequence, D_lm]
 
@@ -72,6 +72,7 @@ class VisionLanguageModel(nn.Module):
             token_embd,
             attention_mask=attention_mask,
             position_ids=position_ids,
+            document_ids=document_ids,
         )
 
         loss = None

--- a/models/vision_language_model.py
+++ b/models/vision_language_model.py
@@ -59,7 +59,7 @@ class VisionLanguageModel(nn.Module):
                 return torch.cat(images, dim=0).to(device)
         return images # Already a tensor
 
-    def forward(self, input_ids, images, attention_mask=None, targets=None):
+    def forward(self, input_ids, images, attention_mask=None, targets=None, position_ids=None):
         images_tensor = self._process_images(images, input_ids.device)
         token_embd = self.decoder.token_embedding(input_ids) # [B, T_sequence, D_lm]
 
@@ -68,7 +68,11 @@ class VisionLanguageModel(nn.Module):
             image_embd = self.MP(image_embd)  # [num_images, mp_image_token_length, D_lm]
             token_embd = self._replace_img_tokens_with_embd(input_ids, token_embd, image_embd)
 
-        logits, _ = self.decoder(token_embd, attention_mask=attention_mask)
+        logits, _ = self.decoder(
+            token_embd,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
 
         loss = None
         if targets is not None:

--- a/tests/benchmark_issue_201_document_ids.py
+++ b/tests/benchmark_issue_201_document_ids.py
@@ -1,0 +1,358 @@
+import argparse
+import gc
+import math
+import sys
+import time
+from pathlib import Path
+from statistics import mean
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from models.language_model import LanguageModel, _to_additive_attention_mask
+
+
+def make_config(
+    hidden_dim,
+    inter_dim,
+    vocab_size,
+    n_heads,
+    n_kv_heads,
+    n_blocks,
+):
+    return SimpleNamespace(
+        lm_hidden_dim=hidden_dim,
+        lm_inter_dim=inter_dim,
+        lm_rms_eps=1e-5,
+        lm_re_base=10000.0,
+        lm_max_position_embeddings=8192,
+        lm_attn_scaling=1.0,
+        lm_vocab_size=vocab_size,
+        lm_n_heads=n_heads,
+        lm_n_kv_heads=n_kv_heads,
+        lm_dropout=0.0,
+        lm_n_blocks=n_blocks,
+        lm_use_tokens=True,
+        lm_tie_weights=True,
+    )
+
+
+def format_bytes(num_bytes):
+    units = ["B", "KiB", "MiB", "GiB"]
+    value = float(num_bytes)
+    for unit in units:
+        if value < 1024.0 or unit == units[-1]:
+            return f"{value:.2f} {unit}"
+        value /= 1024.0
+    return f"{value:.2f} GiB"
+
+
+def build_inputs(batch_size, seq_len, doc_span, vocab_size, device):
+    input_ids = torch.randint(0, vocab_size, (batch_size, seq_len), device=device)
+    labels = torch.randint(0, vocab_size, (batch_size, seq_len), device=device)
+    attention_mask = torch.ones((batch_size, seq_len), dtype=torch.long, device=device)
+
+    position_ids = torch.arange(seq_len, device=device).repeat(batch_size, 1)
+    document_ids = torch.zeros((batch_size, seq_len), dtype=torch.long, device=device)
+
+    for batch_idx in range(batch_size):
+        for start in range(0, seq_len, doc_span):
+            end = min(start + doc_span, seq_len)
+            position_ids[batch_idx, start:end] = torch.arange(end - start, device=device)
+            document_ids[batch_idx, start:end] = start // doc_span
+
+    return {
+        "input_ids": input_ids,
+        "labels": labels,
+        "attention_mask": attention_mask,
+        "position_ids": position_ids,
+        "document_ids": document_ids,
+    }
+
+
+def persistent_extra_bytes(position_ids, document_ids):
+    return (
+        position_ids.numel() * position_ids.element_size()
+        + document_ids.numel() * document_ids.element_size()
+    )
+
+
+def persistent_extra_bytes_from_shape(batch_size, seq_len, dtype=torch.long):
+    element_size = torch.tensor([], dtype=dtype).element_size()
+    return 2 * batch_size * seq_len * element_size
+
+
+def theoretical_mask_bytes(batch_size, seq_len, q_dtype):
+    same_document_bytes = batch_size * seq_len * seq_len
+    additive_mask_bytes = batch_size * seq_len * seq_len * torch.tensor([], dtype=q_dtype).element_size()
+    return same_document_bytes, additive_mask_bytes
+
+
+def synchronize(device):
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def benchmark_mask_builder(device, batch_size, seq_len, q_dtype, steps, warmup, use_document_ids):
+    q = torch.zeros((batch_size, 1, seq_len, 64), dtype=q_dtype, device=device)
+    attention_mask = torch.ones((batch_size, seq_len), dtype=torch.long, device=device)
+    document_ids = torch.arange(seq_len, device=device).div(128, rounding_mode="floor").repeat(batch_size, 1)
+
+    for _ in range(warmup):
+        _ = _to_additive_attention_mask(
+            attention_mask,
+            q,
+            seq_len,
+            seq_len,
+            document_ids=document_ids if use_document_ids else None,
+        )
+    synchronize(device)
+
+    times_ms = []
+    peak_bytes = 0
+    for _ in range(steps):
+        if device.type == "cuda":
+            torch.cuda.reset_peak_memory_stats(device)
+        start = time.perf_counter()
+        mask = _to_additive_attention_mask(
+            attention_mask,
+            q,
+            seq_len,
+            seq_len,
+            document_ids=document_ids if use_document_ids else None,
+        )
+        synchronize(device)
+        times_ms.append((time.perf_counter() - start) * 1000)
+        if device.type == "cuda":
+            peak_bytes = max(peak_bytes, torch.cuda.max_memory_allocated(device))
+        del mask
+    return {
+        "avg_ms": mean(times_ms),
+        "peak_bytes": peak_bytes,
+    }
+
+
+def benchmark_training_mode(mode_name, device, cfg, inputs, steps, warmup):
+    torch.manual_seed(0)
+    model = LanguageModel(cfg).to(device)
+    model.train()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+
+    use_document_ids = mode_name == "document_ids"
+
+    def run_step():
+        optimizer.zero_grad(set_to_none=True)
+        autocast_context = torch.autocast(
+            device_type=device.type,
+            dtype=torch.bfloat16 if device.type == "cuda" else torch.float32,
+        )
+        with autocast_context:
+            logits, _ = model(
+                inputs["input_ids"],
+                attention_mask=inputs["attention_mask"],
+                position_ids=inputs["position_ids"] if use_document_ids else None,
+                document_ids=inputs["document_ids"] if use_document_ids else None,
+            )
+            loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)),
+                inputs["labels"].reshape(-1),
+            )
+        loss.backward()
+        optimizer.step()
+        return loss.item()
+
+    for _ in range(warmup):
+        _ = run_step()
+    synchronize(device)
+
+    times_ms = []
+    peak_bytes = 0
+    losses = []
+    for _ in range(steps):
+        if device.type == "cuda":
+            torch.cuda.reset_peak_memory_stats(device)
+        start = time.perf_counter()
+        losses.append(run_step())
+        synchronize(device)
+        times_ms.append((time.perf_counter() - start) * 1000)
+        if device.type == "cuda":
+            peak_bytes = max(peak_bytes, torch.cuda.max_memory_allocated(device))
+
+    return {
+        "avg_ms": mean(times_ms),
+        "peak_bytes": peak_bytes,
+        "avg_loss": mean(losses),
+    }
+
+
+def print_mode_stats(name, stats, baseline=None):
+    print(f"{name}:")
+    print(f"  avg_step_ms:      {stats['avg_ms']:.2f}")
+    print(f"  peak_memory:      {format_bytes(stats['peak_bytes'])}")
+    print(f"  avg_loss:         {stats['avg_loss']:.4f}")
+    if baseline is not None and baseline["avg_ms"] > 0:
+        print(f"  step_overhead:    {(stats['avg_ms'] / baseline['avg_ms'] - 1.0) * 100:.2f}%")
+    if baseline is not None and baseline["peak_bytes"] > 0:
+        print(f"  memory_overhead:  {(stats['peak_bytes'] / baseline['peak_bytes'] - 1.0) * 100:.2f}%")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Benchmark the training-time cost of issue #201 document_ids masking."
+    )
+    parser.add_argument("--device", choices=("auto", "cpu", "cuda"), default="auto")
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--seq-len", type=int, default=1024)
+    parser.add_argument("--doc-span", type=int, default=128)
+    parser.add_argument("--hidden-dim", type=int, default=960)
+    parser.add_argument("--inter-dim", type=int, default=2560)
+    parser.add_argument("--vocab-size", type=int, default=49152)
+    parser.add_argument("--n-heads", type=int, default=15)
+    parser.add_argument("--n-kv-heads", type=int, default=5)
+    parser.add_argument("--n-blocks", type=int, default=8)
+    parser.add_argument("--steps", type=int, default=5)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--mask-batch-size", type=int, default=2)
+    parser.add_argument("--mask-seq-len", type=int, default=4096)
+    parser.add_argument(
+        "--train-mode",
+        choices=("both", "baseline", "document_ids"),
+        default="both",
+    )
+    parser.add_argument("--skip-training", action="store_true")
+    return parser.parse_args()
+
+
+def resolve_device(device_arg):
+    if device_arg == "cpu":
+        return torch.device("cpu")
+    if device_arg == "cuda":
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA requested but not available.")
+        return torch.device("cuda")
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def main():
+    args = parse_args()
+    device = resolve_device(args.device)
+
+    cfg = make_config(
+        hidden_dim=args.hidden_dim,
+        inter_dim=args.inter_dim,
+        vocab_size=args.vocab_size,
+        n_heads=args.n_heads,
+        n_kv_heads=args.n_kv_heads,
+        n_blocks=args.n_blocks,
+    )
+    inputs = build_inputs(
+        batch_size=args.batch_size,
+        seq_len=args.seq_len,
+        doc_span=args.doc_span,
+        vocab_size=args.vocab_size,
+        device=device,
+    )
+
+    print("Issue #201 document_ids cost benchmark")
+    print(
+        f"device={device}, batch_size={args.batch_size}, seq_len={args.seq_len}, "
+        f"doc_span={args.doc_span}, hidden_dim={args.hidden_dim}, blocks={args.n_blocks}"
+    )
+    print(
+        "benchmark batch overhead from extra tensors: "
+        f"{format_bytes(persistent_extra_bytes(inputs['position_ids'], inputs['document_ids']))}"
+    )
+    print(
+        f"target config extra tensors @ B={args.mask_batch_size}, T={args.mask_seq_len}: "
+        f"{format_bytes(persistent_extra_bytes_from_shape(args.mask_batch_size, args.mask_seq_len))}"
+    )
+
+    if not args.skip_training:
+        baseline_stats = None
+        document_stats = None
+
+        if args.train_mode in ("both", "baseline"):
+            baseline_stats = benchmark_training_mode(
+                "baseline",
+                device,
+                cfg,
+                inputs,
+                steps=args.steps,
+                warmup=args.warmup,
+            )
+            if device.type == "cuda":
+                torch.cuda.empty_cache()
+            gc.collect()
+            print_mode_stats("baseline", baseline_stats)
+
+        if args.train_mode in ("both", "document_ids"):
+            document_stats = benchmark_training_mode(
+                "document_ids",
+                device,
+                cfg,
+                inputs,
+                steps=args.steps,
+                warmup=args.warmup,
+            )
+            if device.type == "cuda":
+                torch.cuda.empty_cache()
+            gc.collect()
+            print_mode_stats("document_ids", document_stats, baseline=baseline_stats)
+
+    q_dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
+    same_document_bytes, additive_mask_bytes = theoretical_mask_bytes(
+        args.mask_batch_size,
+        args.mask_seq_len,
+        q_dtype,
+    )
+    baseline_mask_stats = benchmark_mask_builder(
+        device,
+        batch_size=args.mask_batch_size,
+        seq_len=args.mask_seq_len,
+        q_dtype=q_dtype,
+        steps=args.steps,
+        warmup=args.warmup,
+        use_document_ids=False,
+    )
+    document_mask_stats = benchmark_mask_builder(
+        device,
+        batch_size=args.mask_batch_size,
+        seq_len=args.mask_seq_len,
+        q_dtype=q_dtype,
+        steps=args.steps,
+        warmup=args.warmup,
+        use_document_ids=True,
+    )
+    print("mask_only_estimate:")
+    print(
+        f"  theoretical_same_document_bool @ B={args.mask_batch_size}, T={args.mask_seq_len}: "
+        f"{format_bytes(same_document_bytes)}"
+    )
+    print(
+        f"  theoretical_additive_mask @ B={args.mask_batch_size}, T={args.mask_seq_len}: "
+        f"{format_bytes(additive_mask_bytes)}"
+    )
+    print(
+        f"  baseline_mask_build_avg_ms @ B={args.mask_batch_size}, "
+        f"T={args.mask_seq_len}: {baseline_mask_stats['avg_ms']:.2f}"
+    )
+    print(
+        f"  document_ids_mask_build_avg_ms @ B={args.mask_batch_size}, "
+        f"T={args.mask_seq_len}: {document_mask_stats['avg_ms']:.2f}"
+    )
+    if device.type == "cuda":
+        print(
+            f"  baseline_mask_build_peak: {format_bytes(baseline_mask_stats['peak_bytes'])}"
+        )
+        print(
+            f"  document_ids_mask_build_peak: {format_bytes(document_mask_stats['peak_bytes'])}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmark_issue_201_document_ids.py
+++ b/tests/benchmark_issue_201_document_ids.py
@@ -14,7 +14,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from models.language_model import LanguageModel, _to_additive_attention_mask
+from models.language_model import LanguageModel, _to_boolean_attention_mask
 
 
 def make_config(
@@ -87,10 +87,9 @@ def persistent_extra_bytes_from_shape(batch_size, seq_len, dtype=torch.long):
     return 2 * batch_size * seq_len * element_size
 
 
-def theoretical_mask_bytes(batch_size, seq_len, q_dtype):
+def theoretical_mask_bytes(batch_size, seq_len):
     same_document_bytes = batch_size * seq_len * seq_len
-    additive_mask_bytes = batch_size * seq_len * seq_len * torch.tensor([], dtype=q_dtype).element_size()
-    return same_document_bytes, additive_mask_bytes
+    return same_document_bytes
 
 
 def synchronize(device):
@@ -98,18 +97,23 @@ def synchronize(device):
         torch.cuda.synchronize(device)
 
 
-def benchmark_mask_builder(device, batch_size, seq_len, q_dtype, steps, warmup, use_document_ids):
-    q = torch.zeros((batch_size, 1, seq_len, 64), dtype=q_dtype, device=device)
+def benchmark_mask_builder(device, batch_size, seq_len, steps, warmup, use_document_ids):
+    if not use_document_ids:
+        return {
+            "avg_ms": 0.0,
+            "peak_bytes": 0,
+        }
+
     attention_mask = torch.ones((batch_size, seq_len), dtype=torch.long, device=device)
     document_ids = torch.arange(seq_len, device=device).div(128, rounding_mode="floor").repeat(batch_size, 1)
 
     for _ in range(warmup):
-        _ = _to_additive_attention_mask(
+        _ = _to_boolean_attention_mask(
             attention_mask,
-            q,
             seq_len,
             seq_len,
             document_ids=document_ids if use_document_ids else None,
+            causal=True,
         )
     synchronize(device)
 
@@ -119,12 +123,12 @@ def benchmark_mask_builder(device, batch_size, seq_len, q_dtype, steps, warmup, 
         if device.type == "cuda":
             torch.cuda.reset_peak_memory_stats(device)
         start = time.perf_counter()
-        mask = _to_additive_attention_mask(
+        mask = _to_boolean_attention_mask(
             attention_mask,
-            q,
             seq_len,
             seq_len,
             document_ids=document_ids if use_document_ids else None,
+            causal=True,
         )
         synchronize(device)
         times_ms.append((time.perf_counter() - start) * 1000)
@@ -304,17 +308,14 @@ def main():
             gc.collect()
             print_mode_stats("document_ids", document_stats, baseline=baseline_stats)
 
-    q_dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
-    same_document_bytes, additive_mask_bytes = theoretical_mask_bytes(
+    same_document_bytes = theoretical_mask_bytes(
         args.mask_batch_size,
         args.mask_seq_len,
-        q_dtype,
     )
     baseline_mask_stats = benchmark_mask_builder(
         device,
         batch_size=args.mask_batch_size,
         seq_len=args.mask_seq_len,
-        q_dtype=q_dtype,
         steps=args.steps,
         warmup=args.warmup,
         use_document_ids=False,
@@ -323,7 +324,6 @@ def main():
         device,
         batch_size=args.mask_batch_size,
         seq_len=args.mask_seq_len,
-        q_dtype=q_dtype,
         steps=args.steps,
         warmup=args.warmup,
         use_document_ids=True,
@@ -334,11 +334,7 @@ def main():
         f"{format_bytes(same_document_bytes)}"
     )
     print(
-        f"  theoretical_additive_mask @ B={args.mask_batch_size}, T={args.mask_seq_len}: "
-        f"{format_bytes(additive_mask_bytes)}"
-    )
-    print(
-        f"  baseline_mask_build_avg_ms @ B={args.mask_batch_size}, "
+        f"  baseline_fast_path_mask_build_avg_ms @ B={args.mask_batch_size}, "
         f"T={args.mask_seq_len}: {baseline_mask_stats['avg_ms']:.2f}"
     )
     print(
@@ -347,7 +343,7 @@ def main():
     )
     if device.type == "cuda":
         print(
-            f"  baseline_mask_build_peak: {format_bytes(baseline_mask_stats['peak_bytes'])}"
+            f"  baseline_fast_path_mask_build_peak: {format_bytes(baseline_mask_stats['peak_bytes'])}"
         )
         print(
             f"  document_ids_mask_build_peak: {format_bytes(document_mask_stats['peak_bytes'])}"

--- a/tests/compare_issue_201_fix_strategies.py
+++ b/tests/compare_issue_201_fix_strategies.py
@@ -49,8 +49,7 @@ def build_inputs():
         [[0, 1, 2, 3, 0, 1, 2, 3]], dtype=torch.long
     )
 
-    sample_ids = torch.tensor([[0, 0, 0, -1, 1, 1, 1, -1]], dtype=torch.long)
-    packed_document_mask = build_document_mask(sample_ids)
+    packed_document_ids = torch.tensor([[0, 0, 0, 0, 1, 1, 1, 1]], dtype=torch.long)
 
     sample_b_only = torch.tensor([[*sample_b, pad_token_id]], dtype=torch.long)
     sample_b_only_padding_mask = torch.tensor([[1, 1, 1, 0]], dtype=torch.long)
@@ -61,7 +60,7 @@ def build_inputs():
         "packed_right": packed_right,
         "packed_padding_mask": packed_padding_mask,
         "packed_reset_positions": packed_reset_positions,
-        "packed_document_mask": packed_document_mask,
+        "packed_document_ids": packed_document_ids,
         "sample_b_only": sample_b_only,
         "sample_b_only_padding_mask": sample_b_only_padding_mask,
         "sample_b_only_positions": sample_b_only_positions,
@@ -70,31 +69,13 @@ def build_inputs():
     }
 
 
-def build_document_mask(sample_ids):
-    batch_size, seq_len = sample_ids.shape
-    mask = torch.zeros((batch_size, seq_len, seq_len), dtype=torch.bool)
-
-    for batch_idx in range(batch_size):
-        for query_idx in range(seq_len):
-            query_doc = sample_ids[batch_idx, query_idx].item()
-            if query_doc < 0:
-                mask[batch_idx, query_idx, query_idx] = True
-                continue
-
-            for key_idx in range(seq_len):
-                key_doc = sample_ids[batch_idx, key_idx].item()
-                if key_doc == query_doc:
-                    mask[batch_idx, query_idx, key_idx] = True
-
-    return mask
-
-
-def run_model(model, input_ids, attention_mask, position_ids=None):
+def run_model(model, input_ids, attention_mask, position_ids=None, document_ids=None):
     with torch.no_grad():
         logits, _ = model(
             input_ids,
             attention_mask=attention_mask,
             position_ids=position_ids,
+            document_ids=document_ids,
             start_pos=0,
         )
     return logits
@@ -115,18 +96,21 @@ def compare_mode(
     sample_b_slice,
     packed_position_ids=None,
     sample_b_only_position_ids=None,
+    packed_document_ids=None,
 ):
     packed_left_logits = run_model(
         model,
         packed_left,
         packed_attention_mask,
         position_ids=packed_position_ids,
+        document_ids=packed_document_ids,
     )
     packed_right_logits = run_model(
         model,
         packed_right,
         packed_attention_mask,
         position_ids=packed_position_ids,
+        document_ids=packed_document_ids,
     )
     sample_b_only_logits = run_model(
         model,
@@ -197,15 +181,16 @@ def main():
         ),
         compare_mode(
             model,
-            name="reset_positions_plus_document_mask",
+            name="reset_positions_plus_document_ids",
             packed_left=inputs["packed_left"],
             packed_right=inputs["packed_right"],
-            packed_attention_mask=inputs["packed_document_mask"],
+            packed_attention_mask=inputs["packed_padding_mask"],
             sample_b_only=inputs["sample_b_only"],
             sample_b_only_attention_mask=inputs["sample_b_only_padding_mask"],
             sample_b_slice=sample_b_slice,
             packed_position_ids=inputs["packed_reset_positions"],
             sample_b_only_position_ids=inputs["sample_b_only_positions"],
+            packed_document_ids=inputs["packed_document_ids"],
         ),
     ]
 

--- a/tests/compare_issue_201_fix_strategies.py
+++ b/tests/compare_issue_201_fix_strategies.py
@@ -1,0 +1,242 @@
+import argparse
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from models.language_model import LanguageModel
+
+
+def make_test_config():
+    return SimpleNamespace(
+        lm_hidden_dim=64,
+        lm_inter_dim=128,
+        lm_rms_eps=1e-5,
+        lm_re_base=10000.0,
+        lm_max_position_embeddings=1024,
+        lm_attn_scaling=1.0,
+        lm_vocab_size=256,
+        lm_n_heads=4,
+        lm_n_kv_heads=2,
+        lm_dropout=0.0,
+        lm_n_blocks=2,
+        lm_use_tokens=True,
+        lm_tie_weights=True,
+    )
+
+
+def build_inputs():
+    pad_token_id = 0
+    sample_a_left = [11, 12, 13]
+    sample_a_right = [21, 22, 23]
+    sample_b = [31, 32, 33]
+
+    packed_left = torch.tensor(
+        [[*sample_a_left, pad_token_id, *sample_b, pad_token_id]], dtype=torch.long
+    )
+    packed_right = torch.tensor(
+        [[*sample_a_right, pad_token_id, *sample_b, pad_token_id]], dtype=torch.long
+    )
+    packed_padding_mask = torch.tensor(
+        [[1, 1, 1, 0, 1, 1, 1, 0]], dtype=torch.long
+    )
+    packed_reset_positions = torch.tensor(
+        [[0, 1, 2, 3, 0, 1, 2, 3]], dtype=torch.long
+    )
+
+    sample_ids = torch.tensor([[0, 0, 0, -1, 1, 1, 1, -1]], dtype=torch.long)
+    packed_document_mask = build_document_mask(sample_ids)
+
+    sample_b_only = torch.tensor([[*sample_b, pad_token_id]], dtype=torch.long)
+    sample_b_only_padding_mask = torch.tensor([[1, 1, 1, 0]], dtype=torch.long)
+    sample_b_only_positions = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+
+    return {
+        "packed_left": packed_left,
+        "packed_right": packed_right,
+        "packed_padding_mask": packed_padding_mask,
+        "packed_reset_positions": packed_reset_positions,
+        "packed_document_mask": packed_document_mask,
+        "sample_b_only": sample_b_only,
+        "sample_b_only_padding_mask": sample_b_only_padding_mask,
+        "sample_b_only_positions": sample_b_only_positions,
+        "sample_b_start": 4,
+        "sample_b_length": len(sample_b),
+    }
+
+
+def build_document_mask(sample_ids):
+    batch_size, seq_len = sample_ids.shape
+    mask = torch.zeros((batch_size, seq_len, seq_len), dtype=torch.bool)
+
+    for batch_idx in range(batch_size):
+        for query_idx in range(seq_len):
+            query_doc = sample_ids[batch_idx, query_idx].item()
+            if query_doc < 0:
+                mask[batch_idx, query_idx, query_idx] = True
+                continue
+
+            for key_idx in range(seq_len):
+                key_doc = sample_ids[batch_idx, key_idx].item()
+                if key_doc == query_doc:
+                    mask[batch_idx, query_idx, key_idx] = True
+
+    return mask
+
+
+def run_model(model, input_ids, attention_mask, position_ids=None):
+    with torch.no_grad():
+        logits, _ = model(
+            input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            start_pos=0,
+        )
+    return logits
+
+
+def max_abs_delta(lhs, rhs):
+    return (lhs - rhs).abs().max().item()
+
+
+def compare_mode(
+    model,
+    name,
+    packed_left,
+    packed_right,
+    packed_attention_mask,
+    sample_b_only,
+    sample_b_only_attention_mask,
+    sample_b_slice,
+    packed_position_ids=None,
+    sample_b_only_position_ids=None,
+):
+    packed_left_logits = run_model(
+        model,
+        packed_left,
+        packed_attention_mask,
+        position_ids=packed_position_ids,
+    )
+    packed_right_logits = run_model(
+        model,
+        packed_right,
+        packed_attention_mask,
+        position_ids=packed_position_ids,
+    )
+    sample_b_only_logits = run_model(
+        model,
+        sample_b_only,
+        sample_b_only_attention_mask,
+        position_ids=sample_b_only_position_ids,
+    )
+
+    packed_left_sample_b_logits = packed_left_logits[:, sample_b_slice, :]
+    packed_right_sample_b_logits = packed_right_logits[:, sample_b_slice, :]
+    sample_b_only_slice = sample_b_only_logits[:, : sample_b_slice.stop - sample_b_slice.start, :]
+
+    prefix_delta = max_abs_delta(
+        packed_left_sample_b_logits,
+        packed_right_sample_b_logits,
+    )
+    packed_vs_single_delta = max_abs_delta(
+        packed_left_sample_b_logits,
+        sample_b_only_slice,
+    )
+
+    return {
+        "name": name,
+        "prefix_delta": prefix_delta,
+        "packed_vs_single_delta": packed_vs_single_delta,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare candidate fixes for issue #201 on packed sequences."
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+    model = LanguageModel(make_test_config())
+    model.eval()
+
+    inputs = build_inputs()
+    sample_b_slice = slice(
+        inputs["sample_b_start"],
+        inputs["sample_b_start"] + inputs["sample_b_length"],
+    )
+
+    results = [
+        compare_mode(
+            model,
+            name="baseline_contiguous_positions",
+            packed_left=inputs["packed_left"],
+            packed_right=inputs["packed_right"],
+            packed_attention_mask=inputs["packed_padding_mask"],
+            sample_b_only=inputs["sample_b_only"],
+            sample_b_only_attention_mask=inputs["sample_b_only_padding_mask"],
+            sample_b_slice=sample_b_slice,
+        ),
+        compare_mode(
+            model,
+            name="reset_positions_only",
+            packed_left=inputs["packed_left"],
+            packed_right=inputs["packed_right"],
+            packed_attention_mask=inputs["packed_padding_mask"],
+            sample_b_only=inputs["sample_b_only"],
+            sample_b_only_attention_mask=inputs["sample_b_only_padding_mask"],
+            sample_b_slice=sample_b_slice,
+            packed_position_ids=inputs["packed_reset_positions"],
+            sample_b_only_position_ids=inputs["sample_b_only_positions"],
+        ),
+        compare_mode(
+            model,
+            name="reset_positions_plus_document_mask",
+            packed_left=inputs["packed_left"],
+            packed_right=inputs["packed_right"],
+            packed_attention_mask=inputs["packed_document_mask"],
+            sample_b_only=inputs["sample_b_only"],
+            sample_b_only_attention_mask=inputs["sample_b_only_padding_mask"],
+            sample_b_slice=sample_b_slice,
+            packed_position_ids=inputs["packed_reset_positions"],
+            sample_b_only_position_ids=inputs["sample_b_only_positions"],
+        ),
+    ]
+
+    print("Issue #201 candidate-fix comparison")
+    print(f"seed: {args.seed}")
+    for result in results:
+        print(result["name"] + ":")
+        print(f"  prefix_delta:          {result['prefix_delta']:.6f}")
+        print(f"  packed_vs_single_delta:{result['packed_vs_single_delta']:.6f}")
+
+    baseline = results[0]
+    reset_only = results[1]
+    reset_plus_mask = results[2]
+
+    if baseline["prefix_delta"] <= 1e-6:
+        raise AssertionError("Baseline should show sample-B dependence on sample-A prefix.")
+    if reset_only["prefix_delta"] <= 1e-6:
+        raise AssertionError(
+            "Resetting position ids alone should still leave cross-sample attention active."
+        )
+    if reset_plus_mask["prefix_delta"] >= 1e-5:
+        raise AssertionError(
+            "Adding a document mask should remove sample-B dependence on the sample-A prefix."
+        )
+    if reset_plus_mask["packed_vs_single_delta"] >= 1e-5:
+        raise AssertionError(
+            "With reset position ids and a document mask, packed sample B should match sample B alone."
+        )
+
+    print("comparison_status: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/repro_issue_201_packed_sequences.py
+++ b/tests/repro_issue_201_packed_sequences.py
@@ -1,0 +1,173 @@
+import argparse
+import sys
+from pathlib import Path
+from types import MethodType, SimpleNamespace
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from models.language_model import LanguageModel
+
+
+def make_test_config():
+    return SimpleNamespace(
+        lm_hidden_dim=64,
+        lm_inter_dim=128,
+        lm_rms_eps=1e-5,
+        lm_re_base=10000.0,
+        lm_max_position_embeddings=1024,
+        lm_attn_scaling=1.0,
+        lm_vocab_size=256,
+        lm_n_heads=4,
+        lm_n_kv_heads=2,
+        lm_dropout=0.0,
+        lm_n_blocks=2,
+        lm_use_tokens=True,
+        lm_tie_weights=True,
+    )
+
+
+def build_packed_inputs():
+    pad_token_id = 0
+    sample_a_left = [11, 12, 13]
+    sample_a_right = [21, 22, 23]
+    sample_b = [31, 32, 33]
+
+    packed_left = torch.tensor(
+        [[*sample_a_left, pad_token_id, *sample_b, pad_token_id]], dtype=torch.long
+    )
+    packed_right = torch.tensor(
+        [[*sample_a_right, pad_token_id, *sample_b, pad_token_id]], dtype=torch.long
+    )
+    packed_attention_mask = torch.tensor(
+        [[1, 1, 1, 0, 1, 1, 1, 0]], dtype=torch.long
+    )
+
+    sample_b_only = torch.tensor([[*sample_b, pad_token_id]], dtype=torch.long)
+    sample_b_only_attention_mask = torch.tensor([[1, 1, 1, 0]], dtype=torch.long)
+
+    return {
+        "packed_left": packed_left,
+        "packed_right": packed_right,
+        "packed_attention_mask": packed_attention_mask,
+        "sample_b_only": sample_b_only,
+        "sample_b_only_attention_mask": sample_b_only_attention_mask,
+        "sample_b_start": 4,
+        "sample_b_length": len(sample_b),
+    }
+
+
+def run_and_capture_position_ids(model, input_ids, attention_mask):
+    captured = {}
+    original_forward = model.rotary_embd.forward
+
+    def wrapped_forward(self, position_ids):
+        captured["position_ids"] = position_ids.detach().clone()
+        return original_forward(position_ids)
+
+    model.rotary_embd.forward = MethodType(wrapped_forward, model.rotary_embd)
+    try:
+        with torch.no_grad():
+            logits, _ = model(input_ids, attention_mask=attention_mask, start_pos=0)
+    finally:
+        model.rotary_embd.forward = original_forward
+
+    return captured["position_ids"], logits
+
+
+def max_abs_delta(lhs, rhs):
+    return (lhs - rhs).abs().max().item()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Reproduce issue #201 with packed sequences and contiguous position ids."
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+
+    model = LanguageModel(make_test_config())
+    model.eval()
+
+    inputs = build_packed_inputs()
+
+    packed_position_ids, packed_left_logits = run_and_capture_position_ids(
+        model,
+        inputs["packed_left"],
+        inputs["packed_attention_mask"],
+    )
+    _, packed_right_logits = run_and_capture_position_ids(
+        model,
+        inputs["packed_right"],
+        inputs["packed_attention_mask"],
+    )
+    sample_b_only_position_ids, sample_b_only_logits = run_and_capture_position_ids(
+        model,
+        inputs["sample_b_only"],
+        inputs["sample_b_only_attention_mask"],
+    )
+
+    sample_b_slice = slice(
+        inputs["sample_b_start"],
+        inputs["sample_b_start"] + inputs["sample_b_length"],
+    )
+    packed_left_sample_b_logits = packed_left_logits[:, sample_b_slice, :]
+    packed_right_sample_b_logits = packed_right_logits[:, sample_b_slice, :]
+
+    prefix_delta = max_abs_delta(
+        packed_left_sample_b_logits,
+        packed_right_sample_b_logits,
+    )
+    packed_vs_single_delta = max_abs_delta(
+        packed_left_sample_b_logits,
+        sample_b_only_logits[:, : inputs["sample_b_length"], :],
+    )
+
+    sample_b_start_position = packed_position_ids[0, inputs["sample_b_start"]].item()
+    expected_contiguous_positions = list(range(inputs["packed_left"].shape[1]))
+
+    print("Packed sequence reproduction for issue #201")
+    print(f"seed: {args.seed}")
+    print(f"packed_input_ids:            {inputs['packed_left'][0].tolist()}")
+    print(
+        f"packed_attention_mask:       {inputs['packed_attention_mask'][0].tolist()}"
+    )
+    print(f"captured_position_ids:       {packed_position_ids[0].tolist()}")
+    print(
+        f"sample_b_only_position_ids:  {sample_b_only_position_ids[0].tolist()}"
+    )
+    print(
+        f"sample_b starts at position: {sample_b_start_position} "
+        f"(packed) vs {sample_b_only_position_ids[0, 0].item()} (single sample)"
+    )
+    print(f"expected contiguous ids:     {expected_contiguous_positions}")
+    print(f"max_delta_from_prefix_swap:  {prefix_delta:.6f}")
+    print(f"max_delta_packed_vs_single:  {packed_vs_single_delta:.6f}")
+
+    if packed_position_ids[0].tolist() != expected_contiguous_positions:
+        raise AssertionError(
+            "The reproduction expected contiguous packed position ids, but saw a different pattern."
+        )
+    if sample_b_start_position == 0:
+        raise AssertionError(
+            "The packed reproduction expected sample B to start at a non-zero position id."
+        )
+    if prefix_delta <= 1e-6:
+        raise AssertionError(
+            "Changing sample A should affect sample B logits if cross-sample attention is enabled."
+        )
+    if packed_vs_single_delta <= 1e-6:
+        raise AssertionError(
+            "Packed sample B should differ from sample B alone under the current training semantics."
+        )
+
+    print("reproduction_status: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_packed_sequence_masking.py
+++ b/tests/test_packed_sequence_masking.py
@@ -61,14 +61,13 @@ class TestPackedSequenceMasking(unittest.TestCase):
         ]
 
         packed = dataset._pack_one_group([0, 1], buffer, max_len=8)
-        input_ids, labels, attention_mask, images, position_ids = packed
+        input_ids, labels, attention_mask, images, position_ids, document_ids = packed
 
         self.assertEqual(input_ids.tolist(), [11, 12, 13, 0, 31, 32, 33, 0])
         self.assertEqual(labels.tolist(), [11, 12, 13, -100, 31, 32, 33, -100])
+        self.assertEqual(attention_mask.tolist(), [1, 1, 1, 0, 1, 1, 1, 0])
         self.assertEqual(position_ids.tolist(), [0, 1, 2, 3, 0, 1, 2, 3])
-        self.assertFalse(attention_mask[4, 0].item())
-        self.assertTrue(attention_mask[4, 4].item())
-        self.assertTrue(attention_mask[2, 1].item())
+        self.assertEqual(document_ids.tolist(), [0, 0, 0, 0, 1, 1, 1, 1])
         self.assertEqual(images, [])
 
     def test_reset_position_ids_plus_document_mask_isolates_sample_b(self):
@@ -79,34 +78,22 @@ class TestPackedSequenceMasking(unittest.TestCase):
         packed_right = torch.tensor([[21, 22, 23, 0, 31, 32, 33, 0]], dtype=torch.long)
         padding_mask = torch.tensor([[1, 1, 1, 0, 1, 1, 1, 0]], dtype=torch.long)
         reset_positions = torch.tensor([[0, 1, 2, 3, 0, 1, 2, 3]], dtype=torch.long)
-        document_mask = torch.tensor(
-            [
-                [
-                    [True, True, True, False, False, False, False, False],
-                    [True, True, True, False, False, False, False, False],
-                    [True, True, True, False, False, False, False, False],
-                    [True, True, True, True, False, False, False, False],
-                    [False, False, False, False, True, True, True, False],
-                    [False, False, False, False, True, True, True, False],
-                    [False, False, False, False, True, True, True, False],
-                    [False, False, False, False, True, True, True, True],
-                ]
-            ],
-            dtype=torch.bool,
-        )
+        document_ids = torch.tensor([[0, 0, 0, 0, 1, 1, 1, 1]], dtype=torch.long)
 
         with torch.no_grad():
             baseline_left, _ = model(packed_left, attention_mask=padding_mask)
             baseline_right, _ = model(packed_right, attention_mask=padding_mask)
             fixed_left, _ = model(
                 packed_left,
-                attention_mask=document_mask,
+                attention_mask=padding_mask,
                 position_ids=reset_positions,
+                document_ids=document_ids,
             )
             fixed_right, _ = model(
                 packed_right,
-                attention_mask=document_mask,
+                attention_mask=padding_mask,
                 position_ids=reset_positions,
+                document_ids=document_ids,
             )
 
         sample_b_slice = slice(4, 7)
@@ -143,20 +130,22 @@ class TestPackedSequenceMasking(unittest.TestCase):
                 "attention_mask": packed[2],
                 "images": packed[3],
                 "position_ids": packed[4],
+                "document_ids": packed[5],
             }
         ]
         collated = collator(batch)
 
         self.assertEqual(tuple(collated["input_ids"].shape), (1, 10))
         self.assertEqual(tuple(collated["position_ids"].shape), (1, 10))
-        self.assertEqual(tuple(collated["attention_mask"].shape), (1, 10, 10))
+        self.assertEqual(tuple(collated["document_ids"].shape), (1, 10))
+        self.assertEqual(tuple(collated["attention_mask"].shape), (1, 10))
         self.assertEqual(
             collated["position_ids"][0, -8:].tolist(),
             [0, 1, 2, 3, 0, 1, 2, 3],
         )
-        self.assertTrue(collated["attention_mask"][0, 0, 0].item())
-        self.assertFalse(collated["attention_mask"][0, 0, 1].item())
-        self.assertFalse(collated["attention_mask"][0, -4, -10].item())
+        self.assertEqual(collated["document_ids"][0, -8:].tolist(), [0, 0, 0, 0, 1, 1, 1, 1])
+        self.assertEqual(collated["document_ids"][0, :2].tolist(), [-1, -1])
+        self.assertEqual(collated["attention_mask"][0, -8:].tolist(), [1, 1, 1, 0, 1, 1, 1, 0])
 
 
 if __name__ == "__main__":

--- a/tests/test_packed_sequence_masking.py
+++ b/tests/test_packed_sequence_masking.py
@@ -1,0 +1,163 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from data.advanced_datasets import ConstantLengthDataset
+from data.collators import VQACollator
+from models.language_model import LanguageModel
+
+
+class _FakeTokenizer:
+    pad_token_id = 0
+
+
+class _FakePackedDataset:
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.mp_image_token_length = 1
+
+
+def make_model():
+    cfg = SimpleNamespace(
+        lm_hidden_dim=64,
+        lm_inter_dim=128,
+        lm_rms_eps=1e-5,
+        lm_re_base=10000.0,
+        lm_max_position_embeddings=1024,
+        lm_attn_scaling=1.0,
+        lm_vocab_size=256,
+        lm_n_heads=4,
+        lm_n_kv_heads=2,
+        lm_dropout=0.0,
+        lm_n_blocks=2,
+        lm_use_tokens=True,
+        lm_tie_weights=True,
+    )
+    model = LanguageModel(cfg)
+    model.eval()
+    return model
+
+
+def make_sample(tokens):
+    return {
+        "input_ids": torch.tensor(tokens, dtype=torch.long),
+        "labels": torch.tensor(tokens[:-1] + [-100], dtype=torch.long),
+        "attention_mask": torch.tensor([1, 1, 1, 0], dtype=torch.bool),
+        "images": [],
+    }
+
+
+class TestPackedSequenceMasking(unittest.TestCase):
+    def test_pack_resets_position_ids_and_builds_document_mask(self):
+        dataset = ConstantLengthDataset(
+            _FakePackedDataset(),
+            seq_length=8,
+            num_of_sequences=1,
+        )
+        buffer = [
+            make_sample([11, 12, 13, 0]),
+            make_sample([31, 32, 33, 0]),
+        ]
+
+        packed = dataset._pack_one_group([0, 1], buffer, max_len=8)
+        input_ids, labels, attention_mask, images, position_ids = packed
+
+        self.assertEqual(input_ids.tolist(), [11, 12, 13, 0, 31, 32, 33, 0])
+        self.assertEqual(labels.tolist(), [11, 12, 13, -100, 31, 32, 33, -100])
+        self.assertEqual(position_ids.tolist(), [0, 1, 2, 3, 0, 1, 2, 3])
+        self.assertFalse(attention_mask[4, 0].item())
+        self.assertTrue(attention_mask[4, 4].item())
+        self.assertTrue(attention_mask[2, 1].item())
+        self.assertEqual(images, [])
+
+    def test_reset_position_ids_plus_document_mask_isolates_sample_b(self):
+        torch.manual_seed(0)
+        model = make_model()
+
+        packed_left = torch.tensor([[11, 12, 13, 0, 31, 32, 33, 0]], dtype=torch.long)
+        packed_right = torch.tensor([[21, 22, 23, 0, 31, 32, 33, 0]], dtype=torch.long)
+        padding_mask = torch.tensor([[1, 1, 1, 0, 1, 1, 1, 0]], dtype=torch.long)
+        reset_positions = torch.tensor([[0, 1, 2, 3, 0, 1, 2, 3]], dtype=torch.long)
+        document_mask = torch.tensor(
+            [
+                [
+                    [True, True, True, False, False, False, False, False],
+                    [True, True, True, False, False, False, False, False],
+                    [True, True, True, False, False, False, False, False],
+                    [True, True, True, True, False, False, False, False],
+                    [False, False, False, False, True, True, True, False],
+                    [False, False, False, False, True, True, True, False],
+                    [False, False, False, False, True, True, True, False],
+                    [False, False, False, False, True, True, True, True],
+                ]
+            ],
+            dtype=torch.bool,
+        )
+
+        with torch.no_grad():
+            baseline_left, _ = model(packed_left, attention_mask=padding_mask)
+            baseline_right, _ = model(packed_right, attention_mask=padding_mask)
+            fixed_left, _ = model(
+                packed_left,
+                attention_mask=document_mask,
+                position_ids=reset_positions,
+            )
+            fixed_right, _ = model(
+                packed_right,
+                attention_mask=document_mask,
+                position_ids=reset_positions,
+            )
+
+        sample_b_slice = slice(4, 7)
+        baseline_delta = (
+            baseline_left[:, sample_b_slice, :] - baseline_right[:, sample_b_slice, :]
+        ).abs().max().item()
+        fixed_delta = (
+            fixed_left[:, sample_b_slice, :] - fixed_right[:, sample_b_slice, :]
+        ).abs().max().item()
+
+        self.assertGreater(baseline_delta, 1e-6)
+        self.assertLess(fixed_delta, 1e-5)
+
+    def test_collator_pads_packed_masks_and_position_ids(self):
+        dataset = ConstantLengthDataset(
+            _FakePackedDataset(),
+            seq_length=8,
+            num_of_sequences=1,
+        )
+        collator = VQACollator(_FakeTokenizer(), max_length=10)
+        packed = dataset._pack_one_group(
+            [0, 1],
+            [
+                make_sample([11, 12, 13, 0]),
+                make_sample([31, 32, 33, 0]),
+            ],
+            max_len=8,
+        )
+
+        batch = [
+            {
+                "input_ids": packed[0],
+                "labels": packed[1],
+                "attention_mask": packed[2],
+                "images": packed[3],
+                "position_ids": packed[4],
+            }
+        ]
+        collated = collator(batch)
+
+        self.assertEqual(tuple(collated["input_ids"].shape), (1, 10))
+        self.assertEqual(tuple(collated["position_ids"].shape), (1, 10))
+        self.assertEqual(tuple(collated["attention_mask"].shape), (1, 10, 10))
+        self.assertEqual(
+            collated["position_ids"][0, -8:].tolist(),
+            [0, 1, 2, 3, 0, 1, 2, 3],
+        )
+        self.assertTrue(collated["attention_mask"][0, 0, 0].item())
+        self.assertFalse(collated["attention_mask"][0, 0, 1].item())
+        self.assertFalse(collated["attention_mask"][0, -4, -10].item())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vision_language_model_document_masking.py
+++ b/tests/test_vision_language_model_document_masking.py
@@ -1,0 +1,102 @@
+import unittest
+import sys
+import types
+
+import torch
+
+stub_processors = types.ModuleType("data.processors")
+stub_processors.get_tokenizer = lambda *args, **kwargs: None
+sys.modules.setdefault("data.processors", stub_processors)
+
+from models.config import VLMConfig
+from models.vision_language_model import VisionLanguageModel
+
+
+class FakeTokenizer:
+    image_token_id = 999
+
+
+class TestVisionLanguageModelDocumentMasking(unittest.TestCase):
+    def test_forward_accepts_position_ids_and_document_ids(self):
+        cfg = VLMConfig(
+            vit_model_type="testing",
+            vit_patch_size=16,
+            vit_hidden_dim=48,
+            vit_inter_dim=96,
+            vit_n_heads=3,
+            vit_n_blocks=1,
+            vit_img_size=32,
+            vit_dropout=0.0,
+            lm_model_type="testing",
+            lm_hidden_dim=64,
+            lm_inter_dim=128,
+            lm_rms_eps=1e-5,
+            lm_re_base=10000.0,
+            lm_max_position_embeddings=512,
+            lm_attn_scaling=1.0,
+            lm_vocab_size=128,
+            lm_n_heads=4,
+            lm_n_kv_heads=2,
+            lm_dropout=0.0,
+            lm_n_blocks=2,
+            lm_use_tokens=False,
+            lm_tie_weights=True,
+            mp_pixel_shuffle_factor=2,
+        )
+
+        original_get_tokenizer = sys.modules["models.vision_language_model"].get_tokenizer
+        sys.modules["models.vision_language_model"].get_tokenizer = lambda *args, **kwargs: FakeTokenizer()
+        self.addCleanup(
+            lambda: setattr(
+                sys.modules["models.vision_language_model"],
+                "get_tokenizer",
+                original_get_tokenizer,
+            )
+        )
+
+        model = VisionLanguageModel(cfg, load_backbone=False)
+        model.eval()
+
+        batch_size = 2
+        seq_len = 8
+        input_ids = torch.randint(0, cfg.lm_vocab_size, (batch_size, seq_len))
+        attention_mask = torch.tensor(
+            [
+                [1, 1, 1, 0, 1, 1, 1, 0],
+                [1, 1, 0, 1, 1, 0, 1, 1],
+            ],
+            dtype=torch.long,
+        )
+        position_ids = torch.tensor(
+            [
+                [0, 1, 2, 3, 0, 1, 2, 3],
+                [0, 1, 2, 0, 1, 2, 0, 1],
+            ],
+            dtype=torch.long,
+        )
+        document_ids = torch.tensor(
+            [
+                [0, 0, 0, 0, 1, 1, 1, 1],
+                [0, 0, 0, 1, 1, 1, 2, 2],
+            ],
+            dtype=torch.long,
+        )
+        labels = torch.randint(0, cfg.lm_vocab_size, (batch_size, seq_len))
+        images = [[] for _ in range(batch_size)]
+
+        logits, loss = model(
+            input_ids,
+            images,
+            attention_mask=attention_mask,
+            targets=labels,
+            position_ids=position_ids,
+            document_ids=document_ids,
+        )
+
+        self.assertEqual(tuple(logits.shape), (batch_size, seq_len, cfg.lm_vocab_size))
+        self.assertIsNotNone(loss)
+        self.assertTrue(torch.isfinite(loss))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/train.py
+++ b/train.py
@@ -379,6 +379,7 @@ def train(train_cfg, vlm_cfg):
             labels = batch["labels"].to(device)
             attention_mask = batch["attention_mask"].to(device)
             position_ids = batch["position_ids"].to(device) if "position_ids" in batch else None
+            document_ids = batch["document_ids"].to(device) if "document_ids" in batch else None
             data_load_time = time.time() - data_load_start
 
             # When using DDP with gradient accumulation,
@@ -404,6 +405,7 @@ def train(train_cfg, vlm_cfg):
                         attention_mask=attention_mask,
                         targets=labels,
                         position_ids=position_ids,
+                        document_ids=document_ids,
                     )
 
             if train_cfg.gradient_accumulation_steps > 1:
@@ -474,6 +476,7 @@ def train(train_cfg, vlm_cfg):
                         labels = batch["labels"].to(device)
                         attention_mask = batch["attention_mask"].to(device)
                         position_ids = batch["position_ids"].to(device) if "position_ids" in batch else None
+                        document_ids = batch["document_ids"].to(device) if "document_ids" in batch else None
 
                         with autocast_context:
                             _, loss = model(
@@ -482,6 +485,7 @@ def train(train_cfg, vlm_cfg):
                                 attention_mask=attention_mask,
                                 targets=labels,
                                 position_ids=position_ids,
+                                document_ids=document_ids,
                             )
 
                         total_val_loss += loss.item()

--- a/train.py
+++ b/train.py
@@ -378,6 +378,7 @@ def train(train_cfg, vlm_cfg):
             input_ids = batch["input_ids"].to(device)
             labels = batch["labels"].to(device)
             attention_mask = batch["attention_mask"].to(device)
+            position_ids = batch["position_ids"].to(device) if "position_ids" in batch else None
             data_load_time = time.time() - data_load_start
 
             # When using DDP with gradient accumulation,
@@ -397,7 +398,13 @@ def train(train_cfg, vlm_cfg):
             )
             with autocast_context:
                 with context:
-                    _, loss = model(input_ids, images, attention_mask=attention_mask, targets=labels)
+                    _, loss = model(
+                        input_ids,
+                        images,
+                        attention_mask=attention_mask,
+                        targets=labels,
+                        position_ids=position_ids,
+                    )
 
             if train_cfg.gradient_accumulation_steps > 1:
                 loss = loss / train_cfg.gradient_accumulation_steps
@@ -466,9 +473,16 @@ def train(train_cfg, vlm_cfg):
                         input_ids = batch["input_ids"].to(device)
                         labels = batch["labels"].to(device)
                         attention_mask = batch["attention_mask"].to(device)
+                        position_ids = batch["position_ids"].to(device) if "position_ids" in batch else None
 
                         with autocast_context:
-                            _, loss = model(input_ids, images, attention_mask=attention_mask, targets=labels)
+                            _, loss = model(
+                                input_ids,
+                                images,
+                                attention_mask=attention_mask,
+                                targets=labels,
+                                position_ids=position_ids,
+                            )
 
                         total_val_loss += loss.item()
                         val_batches += 1


### PR DESCRIPTION
## Summary
This PR fixes packed-sequence training so each packed sample keeps its own positional frame and cannot attend across document boundaries.

This started as issue #201 about position IDs in packed sequences. While reproducing it, I found that resetting position IDs alone is not enough: sample B can still attend to sample A unless attention also respects document boundaries.

## What changed
- reset `position_ids` per packed sample in `ConstantLengthDataset`
- emit `document_ids` for packed sequences and carry them through the collator, training loop, evaluation path, and `VisionLanguageModel`
- update `LanguageModel` attention to apply document-aware masking during packed training
- keep the baseline SDPA causal fast path when no explicit document mask is needed
- add a minimal reproduction script, a fix-strategy comparison script, regression tests, and a small overhead benchmark

## Why
With the current packing behavior, two things happen at once:

1. sample B starts from a non-zero position inside the packed sequence
2. sample B can still attend to sample A unless the attention mask is document-aware

The comparison script shows that point pretty clearly:

- baseline contiguous positions: `prefix_delta = 0.462139`
- reset positions only: `prefix_delta = 0.462456`
- reset positions + document-aware masking: `prefix_delta = 0.000000`

So the fix here is intentionally a little broader than just resetting position IDs. It makes packed training semantics line up much more closely with inference semantics.

## Validation
I ran:

- `python -m unittest tests.test_packed_sequence_masking tests.test_language_model tests.test_vision_language_model_document_masking -v`
- `python tests/compare_issue_201_fix_strategies.py`
- `python tests/benchmark_issue_201_document_ids.py --device cuda --train-mode baseline --batch-size 2 --seq-len 4096 --doc-span 128 --hidden-dim 960 --inter-dim 2560 --vocab-size 49218 --n-heads 15 --n-kv-heads 5 --n-blocks 1 --steps 2 --warmup 1 --mask-batch-size 2 --mask-seq-len 4096`
- `python tests/benchmark_issue_201_document_ids.py --device cuda --train-mode document_ids --batch-size 2 --seq-len 4096 --doc-span 128 --hidden-dim 960 --inter-dim 2560 --vocab-size 49218 --n-heads 15 --n-kv-heads 5 --n-blocks 1 --steps 2 --warmup 1 --mask-batch-size 2 --mask-seq-len 4096`
- `python tests/benchmark_issue_201_document_ids.py --device cuda --train-mode baseline --batch-size 1 --seq-len 1024 --doc-span 128 --hidden-dim 960 --inter-dim 2560 --vocab-size 49218 --n-heads 15 --n-kv-heads 5 --n-blocks 32 --steps 10 --warmup 3 --mask-batch-size 2 --mask-seq-len 4096`
- `python tests/benchmark_issue_201_document_ids.py --device cuda --train-mode document_ids --batch-size 1 --seq-len 1024 --doc-span 128 --hidden-dim 960 --inter-dim 2560 --vocab-size 49218 --n-heads 15 --n-kv-heads 5 --n-blocks 32 --steps 10 --warmup 3 --mask-batch-size 2 --mask-seq-len 4096`

A couple of representative numbers from the benchmark:

- `B=2, T=4096, n_blocks=1`: `168.75 ms / 5.77 GiB` -> `181.78 ms / 5.83 GiB`
- `B=1, T=1024, n_blocks=32`: `241.27 ms / 7.07 GiB` -> `254.81 ms / 7.14 GiB`
- extra metadata tensors at `B=2, T=4096` are only `128 KiB`

Closes #201.
