### PR TITLE
[Feat] Add VLMEvalKit integration for nanoVLM evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ eval_results*/
 /shards/*
 *.png
 plots*/
+
+CLAUDE.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "VLMEvalKit"]
+	path = VLMEvalKit
+	url = https://github.com/khurramHashmi/VLMEvalKit.git

--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ We really like `uv` and recommend using it as your package manager. But feel fre
 
 Let's first clone the repository:
 ```bash
-git clone https://github.com/huggingface/nanoVLM.git
+git clone --recurse-submodules https://github.com/huggingface/nanoVLM.git
 cd nanoVLM
 ```
+> [!NOTE]
+> The `--recurse-submodules` flag fetches VLMEvalKit, which is included as a submodule for evaluation. If you already cloned without it, run `git submodule update --init`.
 
 If you want to use `uv`:
 ```bash
@@ -136,6 +138,27 @@ args = argparse.Namespace(
 )
 results = cli_evaluate(args)
 ```
+
+### Evaluation with VLMEvalKit
+
+nanoVLM also supports evaluation using [VLMEvalKit](https://github.com/open-compass/VLMEvalKit), which provides access to a wide range of VLM benchmarks for direct comparison with other models.
+
+```bash
+# One-time setup: clones VLMEvalKit and registers the nanoVLM adapter
+bash eval/setup_vlmevalkit.sh
+
+# Run evaluation (default: nanoVLM-460M-8k on MMStar)
+bash eval/eval_vlmevalkit.sh
+
+# Evaluate a specific model on multiple benchmarks
+bash eval/eval_vlmevalkit.sh nanoVLM-222M MMStar MME OCRBench
+
+# Available registered models:
+#   nanoVLM-460M-8k  (lusxvr/nanoVLM-460M-8k)
+#   nanoVLM-230M-8k  (lusxvr/nanoVLM-230M-8k)
+```
+
+For benchmarks that require an LLM judge (e.g. MMBench, MMVet), set `JUDGE_BASE_URL` and `JUDGE_KEY` environment variables before running.
 
 ## Hub integration
 
@@ -256,7 +279,7 @@ Here are some areas we're looking to work on in the near future. Contributions i
 *   **Multi-gpu training:** Training on several GPUs
 *   **Multi-image support:** Training with several images
 *   **Image-splitting:** Enabling higher resolutions through image-splitting as done in SmolVLM.
-*   **VLMEvalKit:** Integration into [VLMEvalKit](https://github.com/open-compass/VLMEvalKit) to enable further benchmarks
+*   ~~**VLMEvalKit:** Integration into [VLMEvalKit](https://github.com/open-compass/VLMEvalKit) to enable further benchmarks~~
 
 ## Citation
 

--- a/eval/eval_vlmevalkit.sh
+++ b/eval/eval_vlmevalkit.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Evaluate nanoVLM checkpoints on VLMEvalKit benchmarks.
+#
+# Usage:
+#   bash eval/eval_vlmevalkit.sh                                  # defaults: nanoVLM-460M-8k, MMStar
+#   bash eval/eval_vlmevalkit.sh nanoVLM-230M-8k MMStar MME OCRBench # custom model + benchmarks
+#
+# For LLM-judged benchmarks (MMBench, MMVet), set these env vars:
+#   export JUDGE_BASE_URL=http://your-judge:8880/v1
+#   export JUDGE_KEY=EMPTY
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+MODEL="${1:-nanoVLM-460M-8k}"
+shift 2>/dev/null || true
+
+if [ $# -gt 0 ]; then
+    BENCHMARKS="$@"
+else
+    BENCHMARKS="MMStar"
+fi
+
+echo "=== VLMEvalKit: ${MODEL} ==="
+echo "Benchmarks: ${BENCHMARKS}"
+echo "Repo root:  ${REPO_ROOT}"
+
+JUDGE_ARGS=""
+if [ -n "${JUDGE_BASE_URL:-}" ]; then
+    JUDGE_ARGS="--judge-base-url ${JUDGE_BASE_URL} --judge-key ${JUDGE_KEY:-EMPTY}"
+    echo "Judge:      ${JUDGE_BASE_URL}"
+fi
+
+cd "${REPO_ROOT}"
+
+python VLMEvalKit/run.py \
+    --data ${BENCHMARKS} \
+    --model "${MODEL}" \
+    ${JUDGE_ARGS} \
+    --verbose

--- a/eval/setup_vlmevalkit.sh
+++ b/eval/setup_vlmevalkit.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Setup VLMEvalKit for nanoVLM evaluation.
+# This script initializes the VLMEvalKit submodule, installs it, and registers
+# the nanoVLM adapter. Idempotent: safe to run multiple times.
+#
+# Usage:
+#   bash eval/setup_vlmevalkit.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VLMEVALKIT_DIR="${REPO_ROOT}/VLMEvalKit"
+
+echo "=== nanoVLM VLMEvalKit Setup ==="
+echo "Repo root: ${REPO_ROOT}"
+
+# Step 1: Initialize the VLMEvalKit submodule
+echo "[1/4] Initializing VLMEvalKit submodule..."
+cd "${REPO_ROOT}"
+git submodule update --init --recursive VLMEvalKit
+
+# Step 2: Install VLMEvalKit
+echo "[2/4] Installing VLMEvalKit (editable)..."
+pip install -e "${VLMEVALKIT_DIR}"
+
+# Step 3: Copy adapter
+echo "[3/4] Copying nanoVLM adapter..."
+cp "${REPO_ROOT}/eval/vlmevalkit_adapter.py" "${VLMEVALKIT_DIR}/vlmeval/vlm/nanovlm.py"
+echo "  -> ${VLMEVALKIT_DIR}/vlmeval/vlm/nanovlm.py"
+
+# Step 4: Patch VLMEvalKit to register nanoVLM
+echo "[4/4] Patching VLMEvalKit config..."
+python3 - "${VLMEVALKIT_DIR}" <<'PYEOF'
+import sys, os
+
+vlmevalkit_dir = sys.argv[1]
+
+# --- Patch __init__.py ---
+init_path = os.path.join(vlmevalkit_dir, 'vlmeval', 'vlm', '__init__.py')
+with open(init_path, 'r') as f:
+    init_content = f.read()
+
+import_line = 'from .nanovlm import NanoVLM'
+if import_line not in init_content:
+    lines = init_content.rstrip('\n').split('\n')
+    last_import_idx = -1
+    for i, line in enumerate(lines):
+        if line.startswith('from .'):
+            last_import_idx = i
+    if last_import_idx >= 0:
+        lines.insert(last_import_idx + 1, import_line)
+    else:
+        lines.append(import_line)
+    with open(init_path, 'w') as f:
+        f.write('\n'.join(lines) + '\n')
+    print(f"  -> Patched {init_path}")
+else:
+    print(f"  -> {init_path} already patched, skipping.")
+
+# --- Patch config.py ---
+config_path = os.path.join(vlmevalkit_dir, 'vlmeval', 'config.py')
+with open(config_path, 'r') as f:
+    config_content = f.read()
+
+if 'nanovlm_series' not in config_content:
+    nanovlm_block = '''
+nanovlm_series = {
+    "nanoVLM-460M-8k": partial(vlm.NanoVLM, model_path="lusxvr/nanoVLM-460M-8k"),
+    "nanoVLM-230M-8k": partial(vlm.NanoVLM, model_path="lusxvr/nanoVLM-230M-8k"),
+}
+
+'''
+    register_line = 'model_groups.append(nanovlm_series)\n'
+    marker = 'for grp in model_groups:'
+    if marker in config_content:
+        config_content = config_content.replace(
+            marker,
+            nanovlm_block + register_line + '\n' + marker
+        )
+        with open(config_path, 'w') as f:
+            f.write(config_content)
+        print(f"  -> Patched {config_path}")
+    else:
+        print(f"  ERROR: Could not find '{marker}' in {config_path}")
+        print(f"  You may need to manually register nanoVLM in config.py")
+        sys.exit(1)
+else:
+    print(f"  -> {config_path} already patched, skipping.")
+
+print("\n=== Setup complete! ===")
+print("Run evaluation with: bash eval/eval_vlmevalkit.sh")
+PYEOF

--- a/eval/test_vlmevalkit.py
+++ b/eval/test_vlmevalkit.py
@@ -1,0 +1,51 @@
+"""Smoke test: instantiate NanoVLM adapter and run generate_inner on a synthetic sample."""
+import sys
+import os
+
+# Ensure VLMEvalKit is importable
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+vlmevalkit_path = os.path.join(repo_root, 'VLMEvalKit')
+if vlmevalkit_path not in sys.path:
+    sys.path.insert(0, vlmevalkit_path)
+
+from vlmeval.config import supported_VLM
+
+MODEL_NAME = os.environ.get('TEST_MODEL', 'nanoVLM-460M-8k')
+print(f"=== Step 1: Instantiate {MODEL_NAME} ===")
+model_cls = supported_VLM[MODEL_NAME]
+model = model_cls()
+print("Model loaded successfully on CUDA")
+
+print("\n=== Step 2: Test with a dummy text-only message ===")
+message_text = [{"type": "text", "value": "What is 2 + 2?"}]
+result_text = model.generate_inner(message_text, dataset=None)
+print(f"Text-only result: '{result_text}'")
+assert len(result_text) > 0, "FAIL: empty text-only response"
+print("PASS: non-empty text response")
+
+print("\n=== Step 3: Test with image + text ===")
+asset_path = os.path.join(repo_root, 'assets', 'image.png')
+if os.path.exists(asset_path):
+    message_img = [
+        {"type": "image", "value": asset_path},
+        {"type": "text", "value": "What is in this image?"},
+    ]
+    result_img = model.generate_inner(message_img, dataset=None)
+    print(f"Image+text result: '{result_img}'")
+    assert len(result_img) > 0, "FAIL: empty image response"
+    print("PASS: non-empty image response")
+else:
+    print(f"SKIP: test asset not found at {asset_path}")
+
+print("\n=== Step 4: Test MCQ prompt formatting (MMStar-style) ===")
+if os.path.exists(asset_path):
+    message_mcq = [
+        {"type": "image", "value": asset_path},
+        {"type": "text", "value": "What animal is in the image?\nOptions:\nA. Dog\nB. Cat\nC. Bird\nD. Fish\nPlease select the correct answer from the options above."},
+    ]
+    result_mcq = model.generate_inner(message_mcq, dataset="MMStar")
+    print(f"MCQ result: '{result_mcq}'")
+    assert len(result_mcq) > 0, "FAIL: empty MCQ response"
+    print("PASS: non-empty MCQ response")
+
+print("\n=== ALL TESTS PASSED ===")

--- a/eval/vlmevalkit_adapter.py
+++ b/eval/vlmevalkit_adapter.py
@@ -1,0 +1,299 @@
+import os
+import sys
+import warnings
+
+import torch
+from PIL import Image
+
+from .base import BaseModel
+
+# When the adapter is copied to VLMEvalKit/vlmeval/vlm/nanovlm.py inside the nanoVLM repo,
+# three levels up lands at the nanoVLM repo root (models/, data/, etc.)
+NANOVLM_ROOT = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+
+
+def _ensure_nanovlm_importable():
+    abs_root = os.path.abspath(NANOVLM_ROOT)
+    if abs_root not in sys.path:
+        sys.path.insert(0, abs_root)
+
+
+class NanoVLM(BaseModel):
+    INSTALL_REQ = False
+    INTERLEAVE = True
+
+    def __init__(self, model_path='lusxvr/nanoVLM-460M-8k', **kwargs):
+        super().__init__()
+        _ensure_nanovlm_importable()
+
+        from models.vision_language_model import VisionLanguageModel
+        from data.processors import get_tokenizer, get_image_processor
+
+        self.vlm = VisionLanguageModel.from_pretrained(model_path).to('cuda').eval()
+        self.cfg = self.vlm.cfg
+
+        extra_tokens = getattr(self.cfg, 'vlm_extra_tokens', None)
+        chat_template = getattr(self.cfg, 'lm_chat_template', None)
+        self.tokenizer = get_tokenizer(
+            self.cfg.lm_tokenizer, extra_tokens, chat_template,
+        )
+
+        # Older checkpoints (e.g. nanoVLM-222M) were trained without image splitting
+        # and don't have max_img_size / vlm_extra_tokens in their saved config.json.
+        # VLMConfig fills in defaults for missing keys, so we check which keys were
+        # actually present in the saved checkpoint to detect old vs new checkpoints.
+        saved_keys = getattr(self.vlm, '_saved_config_keys', None)
+        has_image_splitting = saved_keys is not None and 'vlm_extra_tokens' in saved_keys
+        if has_image_splitting:
+            max_img = getattr(self.cfg, 'max_img_size', self.cfg.vit_img_size)
+            resize_to_max = getattr(self.cfg, 'resize_to_max_side_len', False)
+        else:
+            max_img = self.cfg.vit_img_size
+            resize_to_max = False
+        self.image_processor = get_image_processor(
+            max_img, self.cfg.vit_img_size, resize_to_max
+        )
+
+        kwargs_default = {'max_new_tokens': 2048}
+        kwargs_default.update(kwargs)
+        self.kwargs = kwargs_default
+        warnings.warn(f'NanoVLM kwargs: {self.kwargs}')
+        torch.cuda.empty_cache()
+
+    # ------------------------------------------------------------------
+    # Core generation entry point required by VLMEvalKit
+    # ------------------------------------------------------------------
+    def generate_inner(self, message, dataset=None):
+        if dataset in self._MMBENCH_DATASETS:
+            prompt, images = self._build_prompt_mmbench(message)
+        elif dataset in ('MMMU_DEV_VAL', 'MMMU_TEST'):
+            prompt, images = self._build_prompt_mmmu(message)
+        elif dataset in ('MathVista_MINI',):
+            prompt, images = self._build_prompt_mathvista(message)
+        elif dataset in ('ChartQA_TEST',):
+            prompt, images = self._build_prompt_chartqa(message)
+        elif dataset in ('DocVQA_VAL', 'DocVQA_TEST'):
+            prompt, images = self._build_prompt_docvqa(message)
+        elif dataset in ('TextVQA_VAL', 'TextVQA_TEST'):
+            prompt, images = self._build_prompt_textvqa(message)
+        elif dataset in (
+            'MME', 'MMVet', 'OCRVQA_TEST', 'OCRVQA_TESTCORE',
+            'InfoVQA_VAL', 'InfoVQA_TEST', 'OCRBench',
+        ):
+            prompt, images = self._build_prompt_default(message, add_brief=True)
+        elif dataset == 'HallusionBench':
+            prompt, images = self._build_prompt_default(message, add_yes_or_no=True)
+        elif dataset in (
+            'MMStar', 'SEEDBench_IMG', 'AI2D_TEST',
+            'ScienceQA_VAL', 'ScienceQA_TEST',
+        ):
+            prompt, images = self._build_prompt_puremcq(message)
+        elif dataset in ('RealWorldQA',):
+            prompt, images = self._build_prompt_puremcq(message)
+        elif dataset in ('POPE',):
+            prompt, images = self._build_prompt_default(message, add_brief=True)
+        elif dataset in ('BLINK',):
+            prompt, images = self._build_prompt_default(message, add_brief=True)
+        elif dataset in ('MM-IFEval',):
+            prompt, images = self._build_prompt_default(message)
+        else:
+            prompt, images = self._build_prompt_default(message)
+
+        return self._run_generation(prompt, images)
+
+    # ------------------------------------------------------------------
+    # Shared generation logic
+    # ------------------------------------------------------------------
+    def _run_generation(self, prompt, pil_images):
+        _ensure_nanovlm_importable()
+        from data.processors import get_image_string
+
+        all_processed = []
+        all_ratios = []
+        for img in pil_images:
+            processed, ratio = self.image_processor(img)
+            if (not hasattr(self.tokenizer, 'global_image_token')
+                    and ratio[0] * ratio[1] == len(processed) - 1):
+                processed = processed[1:]
+            all_processed.append(processed)
+            all_ratios.append(ratio)
+
+        image_string = ''
+        for ratio in all_ratios:
+            image_string += get_image_string(
+                self.tokenizer, [ratio], self.cfg.mp_image_token_length
+            )
+
+        user_content = image_string + prompt
+        messages = [{'role': 'user', 'content': user_content}]
+        full_prompt = self.tokenizer.apply_chat_template(
+            [messages], tokenize=False, add_generation_prompt=True,
+        )
+        if isinstance(full_prompt, list):
+            full_prompt = full_prompt[0]
+
+        inputs = self.tokenizer(
+            [full_prompt],
+            return_tensors='pt',
+            padding=False,
+            truncation=True,
+            max_length=self.cfg.lm_max_position_embeddings,
+        )
+        input_ids = inputs['input_ids'].to('cuda')
+        attention_mask = inputs['attention_mask'].to('cuda')
+
+        images_for_model = all_processed if all_processed else None
+
+        max_new = self.kwargs.get('max_new_tokens', 2048)
+        generated_ids = self.vlm.generate(
+            input_ids,
+            images_for_model,
+            attention_mask,
+            max_new_tokens=max_new,
+            greedy=True,
+        )
+
+        text = self.tokenizer.batch_decode(
+            generated_ids, skip_special_tokens=True
+        )[0]
+        return text.strip()
+
+    # ------------------------------------------------------------------
+    # Per-dataset prompt builders  (ported from SmolVLM2 adapter)
+    # ------------------------------------------------------------------
+    _MMBENCH_DATASETS = {
+        'MMBench_DEV_EN', 'MMBench_TEST_EN', 'MMBench_DEV_CN',
+        'MMBench_TEST_CN', 'MMBench', 'MMBench_CN',
+        'MMBench_DEV_EN_V11', 'MMBench_DEV_CN_V11',
+        'MMBench_TEST_EN_V11', 'MMBench_TEST_CN_V11',
+        'MMBench_V11', 'MMBench_CN_V11', 'CCBench',
+    }
+
+    @staticmethod
+    def _load_images(message):
+        images = []
+        for msg in message:
+            if msg['type'] == 'image':
+                img = Image.open(msg['value']).convert('RGB')
+                images.append(img)
+        return images
+
+    @staticmethod
+    def _get_text(message):
+        return '\n'.join(m['value'].strip() for m in message if m['type'] == 'text')
+
+    def _build_prompt_default(self, message, add_brief=False, add_yes_or_no=False):
+        images = self._load_images(message)
+        text = self._get_text(message)
+        if add_brief:
+            text += '\nGive a very brief answer.'
+        if add_yes_or_no:
+            text += '\nAnswer yes or no.'
+        return text, images
+
+    def _build_prompt_puremcq(self, message):
+        images = self._load_images(message)
+        text = self._get_text(message)
+        replacements = {
+            '\nOptions:': '\nChoices:',
+            'Please select the correct answer from the options above.': 'Answer with the letter.',
+        }
+        for old, new in replacements.items():
+            text = text.replace(old, new)
+        text += '\nAnswer:'
+        return text, images
+
+    def _build_prompt_mmbench(self, message):
+        images = self._load_images(message)
+        text = self._get_text(message)
+        replacements = {
+            '\nOptions:': '\nChoices:',
+            'Please select the correct answer from the options above.': 'Answer with a letter.',
+        }
+        for old, new in replacements.items():
+            text = text.replace(old, new)
+        if text.startswith('Hint:'):
+            try:
+                hint, rest = text.split('\nQuestion:')
+                question, choices = rest.split('\nChoices:')
+                text = 'Question:' + question + '\n' + hint + '\nChoices:' + choices
+            except ValueError:
+                pass
+        text += '\nAnswer:'
+        return text, images
+
+    def _build_prompt_mmmu(self, message):
+        images = self._load_images(message)
+        text = self._get_text(message)
+        replacements = {
+            'Question:': '',
+            'Please select the correct answer from the options above.': 'Answer with the letter.',
+            '\nOptions:': '\nChoices:',
+        }
+        for old, new in replacements.items():
+            text = text.replace(old, new)
+        text = 'Question: ' + text.strip()
+        if 'A.' in text and 'B.' in text:
+            text += '\nAnswer:'
+        return text, images
+
+    def _build_prompt_mathvista(self, message):
+        images = self._load_images(message)
+        text = self._get_text(message)
+        replacements = {
+            '(A) ': 'A. ', '(B) ': 'B. ', '(C) ': 'C. ', '(D) ': 'D. ',
+            '(E) ': 'E. ', '(F) ': 'F. ', '(G) ': 'G. ', '(H) ': 'H. ',
+            '\nOptions:': '\nChoices:',
+            'Hint: ': '',
+        }
+        for old, new in replacements.items():
+            text = text.replace(old, new)
+        if 'A.' in text and 'B.' in text:
+            text += '\nAnswer:'
+        return text, images
+
+    def _build_prompt_chartqa(self, message):
+        images = self._load_images(message)
+        text = self._get_text(message)
+        prefix = (
+            'For the question below, follow the following instructions:\n'
+            '-The answer should contain as few words as possible.\n'
+            "-Don't paraphrase or reformat the text you see in the image.\n"
+            '-Answer a binary question with Yes or No.\n'
+            '-When asked to give a numerical value, provide a number like 2 instead of Two.\n'
+            '-If the final answer has two or more items, provide it in the list format like [1, 2].\n'
+            '-When asked to give a ratio, give out the decimal value like 0.25 instead of 1:4.\n'
+            '-When asked to give a percentage, give out the whole value like 17 instead of decimal like 0.17%.\n'
+            "-Don't include any units in the answer.\n"
+            '-Do not include any full stops at the end of the answer.\n'
+            '-Try to include the full label from the graph when asked about an entity.\n'
+            'Question: '
+        )
+        return prefix + text, images
+
+    def _build_prompt_docvqa(self, message):
+        images = self._load_images(message)
+        text = self._get_text(message)
+        prefix = (
+            'Give a short and terse answer to the following question. '
+            'Do not paraphrase or reformat the text you see in the image. '
+            'Do not include any full stops. '
+            'Just give the answer without additional explanation. Question: '
+        )
+        return prefix + text, images
+
+    def _build_prompt_textvqa(self, message):
+        images = self._load_images(message)
+        text = self._get_text(message)
+        prefix = (
+            'Answer the following question about the image using as few words as possible. '
+            'Follow these additional instructions:\n'
+            '-Always answer a binary question with Yes or No.\n'
+            '-When asked what time it is, reply with the time seen in the image.\n'
+            '-Do not put any full stops at the end of the answer.\n'
+            '-Do not put quotation marks around the answer.\n'
+            '-An answer with one or two words is favorable.\n'
+            '-Do not apply common sense knowledge. The answer can be found in the image.\n'
+            'Question: '
+        )
+        return prefix + text, images

--- a/models/vision_language_model.py
+++ b/models/vision_language_model.py
@@ -219,12 +219,19 @@ class VisionLanguageModel(nn.Module):
                 repo_id=repo_id_or_path, filename="model.safetensors", revision=revision
             )
 
-        # Load config
+        # Load config, filtering unknown keys for backward compat with older checkpoints
         with open(config_path, "r") as f:
-            cfg = VLMConfig(**json.load(f))
+            raw_cfg = json.load(f)
+        from dataclasses import fields as dc_fields
+        valid_keys = {fld.name for fld in dc_fields(VLMConfig)}
+        cfg = VLMConfig(**{k: v for k, v in raw_cfg.items() if k in valid_keys})
 
         # Initialize model without loading the backbone
         model = cls(cfg, load_backbone=False)
+        # Expose which keys were actually present in the saved config so that
+        # downstream code (e.g. eval adapters) can distinguish old checkpoints
+        # from new ones, even when VLMConfig fills in defaults for missing keys.
+        model._saved_config_keys = set(raw_cfg.keys())
 
         # Load safetensors weights
         load_model(model, weights_path)


### PR DESCRIPTION
This PR integrates [VLMEvalKit](https://github.com/open-compass/VLMEvalKit) into nanoVLM as a second evaluation framework alongside the existing lmms-eval integration, enabling evaluation across a broader set of multimodal benchmarks with minimal setup.

  ## What's added

  **VLMEvalKit adapter** (`eval/vlmevalkit_adapter.py`): A `BaseModel` subclass that wires nanoVLM's tokenizer, image processor, and `VisionLanguageModel` into the VLMEvalKit inference API. Handles per-dataset
   prompt formatting (MMBench, MMMU, MathVista, ChartQA, DocVQA, TextVQA, MCQ) and supports both image-splitting and non-splitting model variants.

  **Setup script** (`eval/setup_vlmevalkit.sh`): Idempotent script that initialises the VLMEvalKit submodule, installs it in editable mode, copies the adapter, and patches VLMEvalKit's `__init__.py` and
  `config.py` to register `nanoVLM-460M-8k` and `nanoVLM-230M-8k`.

  **Launcher script** (`eval/eval_vlmevalkit.sh`): Convenience wrapper with sensible defaults (`nanoVLM-460M-8k` on MMStar). Accepts custom model and benchmark arguments, and forwards optional LLM-judge env
  vars for benchmarks like MMBench.

  **Smoke test** (`eval/test_vlmevalkit.py`): Covers text-only, image+text, and MCQ inference paths.

  ## Usage

  ```bash
  # One-time setup
  bash eval/setup_vlmevalkit.sh

  # Run default: nanoVLM-460M-8k on MMStar
  bash eval/eval_vlmevalkit.sh

  # Custom model + benchmarks
  bash eval/eval_vlmevalkit.sh nanoVLM-222M MMStar MME OCRBench

  # Smoke test
  python eval/test_vlmevalkit.py
```

  ## Other changes

  - models/vision_language_model.py: filters unknown keys from old checkpoint configs for backward compatibility; exposes _saved_config_keys so adapters can detect which optional fields were actually
  persisted.
  - README.md: adds --recurse-submodules clone note, VLMEvalKit eval section, and marks the roadmap item as done.
  - VLMEvalKit added as a git submodule pointing to a fork with the nanoVLM adapter pre-registered.

  ## Acknowledgments

  This integration builds upon the excellent work of the https://github.com/open-compass/VLMEvalKit project from OpenCompass, which provides a unified framework for evaluating large vision-language models
  across a wide range of multimodal benchmarks.

  ## Note
This PR maintains nanoVLM's philosophy of simplicity and minimal dependencies while complementing the existing lmms-eval integration. VLMEvalKit and lmms-eval serve overlapping but distinct benchmark ecosystems, and having both lowers friction for researchers who prefer one over the other. The integration is designed to be entirely opt-in and non-intrusive to existing training and inference workflows.